### PR TITLE
expose PdfString's start and end bytes positions in Stream

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfString.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfString.cs
@@ -284,7 +284,21 @@ namespace PdfSharp.Pdf
         /// </summary>
         internal override void WriteObject(PdfWriter writer)
         {
+            PositionStart = writer.Position;
+
             writer.Write(this);
+
+            PositionEnd = writer.Position;
         }
+
+        /// <summary>
+        /// Position of the first byte of this string in PdfWriter's Stream
+        /// </summary>
+        public int PositionStart { get; internal set; }
+
+        /// <summary>
+        /// Position of the last byte of this string in PdfWriter's Stream
+        /// </summary>
+        public int PositionEnd { get; internal set; }
     }
 }


### PR DESCRIPTION
This will make possible the implementation of document signature, because to do so we need to exclude this specific byte range from the hash digest.
There is no other way to properly know that byte range without doing lots of changes as it has been done in https://github.com/empira/PDFsharp-1.5/pull/11

Exposing this range will be enough to allow the development of a PdfSharp extension that support document signing (I'll do it).

If you're ready to consider it though, I can also do a pull request to directly embed this feature into the official PdfSharp repo.
If you do not merge this pull request, and neither consider consider accepting a pull request for a signature feature, I'll create a fork anyway.

Please let me know your thougts about this topic.