### PR TITLE
Handle xref-streams based on their file-position (last one first)

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
@@ -1204,6 +1204,9 @@ namespace PdfSharp.Pdf.IO
             // Read cross reference stream.
             //Debug.Assert(_lexer.Symbol == Symbol.Integer);
 
+            // remember start-position of xref-stream
+            var xrefStart = _lexer.Position - _lexer.Token.Length;
+
             int number = _lexer.TokenToInteger;
             int generation = ReadInteger();
             // According to specs, generation number "shall not" be "other than zero".
@@ -1227,7 +1230,8 @@ namespace PdfSharp.Pdf.IO
             var iref = new PdfReference(xrefStream)
             {
                 ObjectID = objectID,
-                Value = xrefStream
+                Value = xrefStream,
+                Position = xrefStart
             };
             xrefTable.Add(iref);
 


### PR DESCRIPTION
This PR attempts to correct an issue that is described in #46 .

By sorting the xref-streams of the file in descending file-order the most recent one is read first, as it should be done (according to the spec).
