### PR TITLE
Add TextWithShapeFormat to support fBehindDocument

### DIFF
--- a/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Shapes/Shape.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Shapes/Shape.cs
@@ -126,6 +126,19 @@ namespace MigraDoc.DocumentObjectModel.Shapes
         }
 
         /// <summary>
+        /// Gets the text in front or behind format of the shape.
+        /// </summary>
+        public TextWithShapeFormat TextWithShapeFormat
+        {
+            get => Values.TextWithShapeFormat ??= new TextWithShapeFormat(this);
+            set
+            {
+                SetParent(value);
+                Values.TextWithShapeFormat = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the height of the shape.
         /// </summary>
         public Unit Height
@@ -233,6 +246,12 @@ namespace MigraDoc.DocumentObjectModel.Shapes
             /// See enclosing document object class for documentation of this property.
             /// </summary>
             public FillFormat? FillFormat { get; set; }
+
+            /// <summary>
+            /// Gets or sets the internal nullable implementation value of the enclosing document object property.
+            /// See enclosing document object class for documentation of this property.
+            /// </summary>
+            public TextWithShapeFormat? TextWithShapeFormat { get; set; }
 
             /// <summary>
             /// Gets or sets the internal nullable implementation value of the enclosing document object property.

--- a/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Shapes/TextWithShapeFormat.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Shapes/TextWithShapeFormat.cs
@@ -1,0 +1,52 @@
+// MigraDoc - Creating Documents on the Fly
+// See the LICENSE file in the solution root for more information.
+
+namespace MigraDoc.DocumentObjectModel.Shapes
+{
+    /// <summary>
+    /// A TextWithShapeFormat object
+    /// Defines the background filling of the shape.
+    /// </summary>
+    public class TextWithShapeFormat : DocumentObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the FillFormat class.
+        /// </summary>
+        public TextWithShapeFormat() { }
+
+        /// <summary>
+        /// Initializes a new instance of the FillFormat class with the specified parent.
+        /// </summary>
+        internal TextWithShapeFormat(DocumentObject parent) : base(parent) { }
+
+        /// <summary>
+        /// Creates a deep copy of this object.
+        /// </summary>
+        public new TextWithShapeFormat Clone()
+            => (TextWithShapeFormat)DeepCopy();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the text should be in front of the shape.
+        /// </summary>
+        public bool? TextInFront { get; set; }
+
+        /// <summary>
+        /// Converts FillFormat into DDL.
+        /// </summary>
+        internal override void Serialize(Serializer serializer)
+        {
+            int pos = serializer.BeginContent("TextWithShapeFormat");
+            if (this.TextInFront.HasValue)
+                serializer.WriteSimpleAttribute("TextInFront", this.TextInFront.Value);
+
+            serializer.EndContent();
+        }
+
+        /// <summary>
+        /// Returns the meta object of this instance.
+        /// </summary>
+        internal override Meta Meta => TheMeta;
+
+        static readonly Meta TheMeta = new(typeof(TextWithShapeFormat));
+    }
+}

--- a/src/foundation/src/MigraDoc/src/MigraDoc.RtfRendering/RtfRendering/ShapeRenderer.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.RtfRendering/RtfRendering/ShapeRenderer.cs
@@ -57,6 +57,7 @@ namespace MigraDoc.RtfRendering
             }
             RenderLineFormat();
             RenderFillFormat();
+            RenderTextWithShapeFormat();
         }
 
         /// <summary>
@@ -72,6 +73,15 @@ namespace MigraDoc.RtfRendering
             }
             else
                 RenderNameValuePair("fFilled", "0");
+        }
+
+        protected void RenderTextWithShapeFormat()
+        {
+            var tf = GetValueAsIntended("TextWithShapeFormat") as TextWithShapeFormat;
+            if (tf != null && tf.TextInFront.HasValue && tf.TextInFront.Value)
+                RenderNameValuePair("fBehindDocument", "0");
+            else
+                RenderNameValuePair("fBehindDocument", "1");
         }
 
         protected Unit GetLineWidth()


### PR DESCRIPTION
I added this to the my local build of Migradoc v1.5 for a project where I needed it. I just ported it over to 6.0 and thought I should share. Not sure it's complete, I only used the RTF part so that is what I tested. Adds `fBehindDocument` RTF property to allow text to be on top of shapes. 

Open to input, I am not a document expert.