### PR TITLE
Refactor XLineAlignment for clearer vertical text alignment descriptions

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Drawing/enums/XLineAlignment.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Drawing/enums/XLineAlignment.cs
@@ -4,31 +4,31 @@
 namespace PdfSharp.Drawing
 {
     /// <summary>
-    /// Specifies the alignment of a text string relative to its layout rectangle.
+    /// Specifies the vertical alignment of a text string, 
+    /// relative to its starting point or rectangle layout
     /// </summary>
-    public enum XLineAlignment  // Same values as System.Drawing.StringAlignment (except BaseLine)
+    public enum XLineAlignment
     {
         /// <summary>
-        /// Specifies the text be aligned near the layout.
-        /// In a left-to-right layout, the near position is left. In a right-to-left layout, the near
-        /// position is right.
+        /// Using Rectangle layout, text is vertically aligned inside and near the top of the layout.
+        /// Using Point, text is vertically aligned below the point.
         /// </summary>
         Near = 0,
 
-        /// <summary>
-        /// Specifies that text is aligned in the center of the layout rectangle.
+       /// <summary>
+        /// Using Rectangle layout, text is vertically aligned in the center of the layout.
+        /// Using Point, text is vertically aligned on the center of the point.
         /// </summary>
         Center = 1,
 
         /// <summary>
-        /// Specifies that text is aligned far from the origin position of the layout rectangle.
-        /// In a left-to-right layout, the far position is right. In a right-to-left layout, the far
-        /// position is left. 
+        /// Using Rectangle layout, text is vertically aligned inside and near the bottom of the layout.
+        /// Using Point, text is vertically aligned above the point.
         /// </summary>
         Far = 2,
 
         /// <summary>
-        /// Specifies that text is aligned relative to its base line.
+        /// Specifies that text is aligned vertically relative to its base line.
         /// With this option the layout rectangle must have a height of 0.
         /// </summary>
         BaseLine = 3,


### PR DESCRIPTION
This commit refactors the XLineAlignment enumeration to provide clearer descriptions of vertical text alignment options in various contexts. The updated comments now distinguish between 'Rectangle' and 'Point' layout behaviors for 'Near', 'Center', and 'Far' alignments. The 'BaseLine' option remains unchanged, still specifying alignment relative to the text's baseline.