### PR TITLE
Use lazy loading for object-streams and their objects

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Internal/Diagnostics.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Internal/Diagnostics.cs
@@ -73,11 +73,11 @@ namespace PdfSharp.Internal
                 "If you think this is a bug in PDFsharp, please send us your PDF file.", (int)ch);
             ThrowParserException(message);
         }
-        public static void HandleUnexpectedToken(string token)
+        public static void HandleUnexpectedToken(string token, int position)
         {
             string message = String.Format(CultureInfo.InvariantCulture,
-                "Unexpected token '{0}' in PDF stream. The file may be corrupted. " +
-                "If you think this is a bug in PDFsharp, please send us your PDF file.", token);
+                "Unexpected token '{0}' at position {1} in PDF stream. The file may be corrupted. " +
+                "If you think this is a bug in PDFsharp, please send us your PDF file.", token, position);
             ThrowParserException(message);
         }
     }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceStream.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceStream.cs
@@ -12,7 +12,7 @@ namespace PdfSharp.Pdf.Advanced
     sealed class PdfCrossReferenceStream : PdfTrailer  // Reference: 3.4.7  Cross-Reference Streams / Page 106
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PdfObjectStream"/> class.
+        /// Initializes a new instance of the <see cref="PdfCrossReferenceStream"/> class.
         /// </summary>
         public PdfCrossReferenceStream(PdfDocument document)
             : base(document)

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfObjectStream.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfObjectStream.cs
@@ -52,37 +52,6 @@ namespace PdfSharp.Pdf.Advanced
         /// <summary>
         /// Reads the compressed object with the specified index.
         /// </summary>
-        internal void ReadReferences(PdfCrossReferenceTable xrefTable)
-        {
-            ////// Create parser for stream.
-            ////Parser parser = new Parser(_document, new MemoryStream(Stream.Value));
-            for (int idx = 0; idx < _header.Length; idx++)
-            {
-                int objectNumber = _header[idx][0];
-                int offset = _header[idx][1];
-
-                PdfObjectID objectID = new PdfObjectID(objectNumber);
-
-                // HACK: -1 indicates compressed object.
-                PdfReference iref = new PdfReference(objectID, -1);
-                ////iref.ObjectID = objectID;
-                ////iref.Value = xrefStream;
-                if (!xrefTable.Contains(iref.ObjectID))
-                {
-                    xrefTable.Add(iref);
-                }
-                else
-                {
-#if DEBUG
-                    GetType();
-#endif
-                }
-            }
-        }
-
-        /// <summary>
-        /// Reads the compressed object with the specified index.
-        /// </summary>
         internal PdfReference ReadCompressedObject(int index)
         {
             Parser parser = new Parser(_document, new MemoryStream(Stream.Value));
@@ -108,7 +77,7 @@ namespace PdfSharp.Pdf.Advanced
 
             /// <summary>
             /// (Required) The type of PDF object that this dictionary describes;
-            /// must be ObjStmfor an object stream.
+            /// must be ObjStm for an object stream.
             /// </summary>
             [KeyInfo(KeyType.Name | KeyType.Required, FixedValue = "ObjStm")]
             public const string Type = "/Type";
@@ -130,7 +99,7 @@ namespace PdfSharp.Pdf.Advanced
             /// (Optional) A reference to an object stream, of which the current object
             /// stream is considered an extension. Both streams are considered part of
             /// a collection of object streams (see below). A given collection consists
-            /// of a set of streams whose Extendslinks form a directed acyclic graph.
+            /// of a set of streams whose Extends links form a directed acyclic graph.
             /// </summary>
             [KeyInfo(KeyType.Stream | KeyType.Optional)]
             public const string Extends = "/Extends";

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfReference.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfReference.cs
@@ -17,7 +17,7 @@ namespace PdfSharp.Pdf.Advanced
     /// Represents an indirect reference to a PdfObject.
     /// </summary>
     [DebuggerDisplay("iref({ObjectNumber}, {GenerationNumber})")]
-    public sealed class PdfReference : PdfItem
+    public class PdfReference : PdfItem
     {
         // About PdfReference 
         // 
@@ -154,7 +154,7 @@ namespace PdfSharp.Pdf.Advanced
         /// <summary>
         /// Gets or sets the referenced PdfObject.
         /// </summary>
-        public PdfObject Value
+        public virtual PdfObject Value
         {
             get => _value;
             set
@@ -245,5 +245,94 @@ namespace PdfSharp.Pdf.Advanced
         static int s_counter = 0;
         int _uid;
 #endif
+    }
+
+    /// <summary>
+    /// Represents an indirect reference to an object stored in an <see cref="PdfObjectStream"/><br></br>
+    /// The value of this object is "lazily" loaded when first accessed.
+    /// </summary>
+    public sealed class PdfReferenceToCompressedObject : PdfReference
+    {
+        private readonly int _objectStreamNumber;
+        private readonly int _indexInObjectStream;
+
+        internal PdfReferenceToCompressedObject(PdfDocument doc, PdfObjectID objectID,
+            int objectStreamNumber, int indexInObjectStream)
+            : base(objectID, -1)
+        {
+            Document = doc ?? throw new ArgumentNullException(nameof(doc));
+            _objectStreamNumber = objectStreamNumber;
+            _indexInObjectStream = indexInObjectStream;
+        }
+
+        public override PdfObject Value
+        {
+            get
+            {
+                if (base.Value is null)
+                {
+                    ReadValue();
+                }
+                return base.Value!;
+            }
+            set => base.Value = value;
+        }
+
+        /// <summary>
+        /// Reads the value of this object
+        /// </summary>
+        void ReadValue()
+        {
+            PdfObjectStream? ostm = null;
+            var stmObjID = new PdfObjectID(_objectStreamNumber);
+            // reference to object stream
+            var streamRef = Document.IrefTable[stmObjID];
+            if (streamRef is not null)
+            {
+                if (streamRef.Value is null)
+                {
+                    // object stream not yet loaded. do it now
+                    var parser = Document.GetParser()!;
+                    var state = parser.SaveState();
+                    var obj = parser.ReadObject(null, stmObjID, false, false);
+                    if (obj is PdfDictionary ostmDict)
+                    {
+                        // decrypt if necessary
+                        // must be done before type-transformation because PdfObjectStream
+                        // tries to parse the stream-header in the constructor
+                        Document.EffectiveSecurityHandler?.DecryptObject(ostmDict);
+                        ostm = new PdfObjectStream(ostmDict);
+                    }
+                    parser.RestoreState(state);
+                    Debug.Assert(ostm != null, "Object stream should not be null here");
+                }
+                // already transformed ?
+                else if (streamRef.Value is not PdfObjectStream existingOstm)
+                {
+                    if (streamRef.Value is PdfDictionary ostmDict)
+                    {
+                        // decrypt if necessary
+                        Document.EffectiveSecurityHandler?.DecryptObject(ostmDict);
+                        ostm = new PdfObjectStream(ostmDict);
+                    }
+                    Debug.Assert(ostm != null, "Object stream should not be null here");
+                }
+                else
+                    ostm = existingOstm;
+
+                if (ostm is not null)
+                {
+                    // store the loaded and decrypted object-stream
+                    streamRef.Value = ostm;
+                    // read the actual object we're looking for
+                    var iref = ostm.ReadCompressedObject(_indexInObjectStream);
+                    if (iref is not null)
+                    {
+                        Debug.Assert(iref.ObjectID == ObjectID, "ObjectID mismatch");
+                        base.Value = iref.Value;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Lexer.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Lexer.cs
@@ -937,8 +937,8 @@ namespace PdfSharp.Pdf.IO
         {
             get
             {
-                // ReSharper disable once CompareOfFloatsByEqualityOperator
-                Debug.Assert(_tokenAsReal == double.Parse(_token.ToString(), CultureInfo.InvariantCulture));
+                // had several documents where the assertion failed with an equality comparision (==)
+                Debug.Assert(Math.Abs(_tokenAsReal - double.Parse(_token.ToString(), CultureInfo.InvariantCulture)) < 0.000000001);
                 return _tokenAsReal;
             }
         }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
@@ -42,10 +42,10 @@ namespace PdfSharp.Pdf.IO
             _stack = new ShiftStack();
         }
 
-        public Parser(PdfDocument document)
+        public Parser(PdfDocument document, Lexer lexer)
         {
-            _document = document;
-            _lexer = document?._lexer ?? throw new ArgumentNullException(nameof(document), "Lexer not defined.");
+            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _lexer = lexer ?? throw new ArgumentNullException(nameof(lexer));
             _stack = new ShiftStack();
         }
 
@@ -105,7 +105,7 @@ namespace PdfSharp.Pdf.IO
                 {
                     // Attempt to read an object that was already registered. Keep the former object.
                     // This only happens with corrupt PDF files that have duplicate IDs.
-                    if (iref.Value != null!)
+                    if (iref is not PdfReferenceToCompressedObject && iref.Value != null!)
                     {
                         LogHost.Logger.LogWarning("Another instance of object {iref} was found. Using previously encountered object instead.", iref);
                         // Attempt to read an object that was already read. Keep the former object.
@@ -258,12 +258,12 @@ namespace PdfSharp.Pdf.IO
 
                 case Symbol.Keyword:
                     // Should not come here anymore.
-                    ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+                    ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
                     break;
 
                 default:
                     // Should not come here anymore.
-                    ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+                    ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
                     break;
             }
             symbol = ScanNextToken();
@@ -344,19 +344,10 @@ namespace PdfSharp.Pdf.IO
             {
 #if true
                 object length;
-                if (reference.Position == -1 && reference.Value != null!)
-                {
-                    if (reference.Value is not PdfIntegerObject integer)
-                        throw new InvalidOperationException("Cannot retrieve stream length from stream object.");
+                if (reference.Value is not PdfIntegerObject integer)
+                    throw new InvalidOperationException("Cannot retrieve stream length from stream object.");
 
-                    length = integer;
-                }
-                else
-                {
-                    ParserState state = SaveState();
-                    length = ReadObject(null, reference.ObjectID, false, false);
-                    RestoreState(state);
-                }
+                length = integer;
 #else
                 ParserState state = SaveState();
                 object length = ReadObject(null, reference.ObjectID, false, false);
@@ -558,7 +549,7 @@ namespace PdfSharp.Pdf.IO
                     //case Symbol.StartXRef:
                     //case Symbol.Eof:
                     default:
-                        ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+                        ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
                         SkipCharsUntil(stop);
                         return;
                 }
@@ -673,7 +664,7 @@ namespace PdfSharp.Pdf.IO
             }
             Symbol current = _lexer.ScanNextToken();
             if (symbol != current)
-                ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+                ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
             return current;
         }
 
@@ -684,7 +675,7 @@ namespace PdfSharp.Pdf.IO
         {
             Symbol current = _lexer.ScanNextToken();
             if (token != _lexer.Token)
-                ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+                ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
             return current;
         }
 
@@ -696,7 +687,7 @@ namespace PdfSharp.Pdf.IO
             string name;
             Symbol symbol = ScanNextToken(out name);
             if (symbol != Symbol.Name)
-                ParserDiagnostics.HandleUnexpectedToken(name);
+                ParserDiagnostics.HandleUnexpectedToken(name, _lexer.Position - name.Length);
             return name;
         }
 
@@ -773,7 +764,7 @@ namespace PdfSharp.Pdf.IO
                 _lexer.Position = position;
                 return n;
             }
-            ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+            ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
             return 0;
         }
 
@@ -824,114 +815,8 @@ namespace PdfSharp.Pdf.IO
         //    }
 
         /// <summary>
-        /// Reads an object from the PDF input stream using the default parser.
-        /// </summary>
-        public static PdfObject ReadObject(PdfDocument owner, PdfObjectID objectID)
-        {
-            if (owner == null)
-                throw new ArgumentNullException(nameof(owner));
-
-            Parser parser = new Parser(owner);
-            return parser.ReadObject(null, objectID, false, false);
-        }
-
-        /// <summary>
-        /// Reads the irefs from the compressed object with the specified index in the object stream
-        /// of the object with the specified object id.
-        /// </summary>
-        internal void ReadIRefsFromCompressedObject(PdfObjectID objectID)
-        {
-            Debug.Assert(_document.IrefTable.ObjectTable.ContainsKey(objectID));
-            if (!_document.IrefTable.ObjectTable.TryGetValue(objectID, out var iref))
-            {
-                // We should never come here because the object stream must be a type 1 entry in the xref stream
-                // and iref was created before.
-                throw new NotImplementedException("This case is not coded or something else went wrong");
-            }
-
-            Debug.Assert(iref.Value != null, "The object shall be read in by PdfReader.ReadIndirectObjectsFromIrefTable() before accessing it.");
-
-            if (iref.Value is not PdfObjectStream objectStreamStream)
-            {
-                Debug.Assert(((PdfDictionary)iref.Value).Elements.GetName("/Type") == "/ObjStm");
-
-                objectStreamStream = new PdfObjectStream((PdfDictionary)iref.Value);
-                Debug.Assert(objectStreamStream.Reference == iref);
-                // objectStream.Reference = iref; Superfluous, see Assert in line before.
-                Debug.Assert(objectStreamStream.Reference.Value != null, "Something went wrong.");
-            }
-            Debug.Assert(objectStreamStream != null);
-
-            //PdfObjectStream objectStreamStream = (PdfObjectStream)iref.Value;
-            if (objectStreamStream == null)
-                throw new Exception("Something went wrong here.");
-            objectStreamStream.ReadReferences(_document.IrefTable);
-        }
-
-        /// <summary>
-        /// Reads the compressed object with the specified index in the object stream
-        /// of the object with the specified object ID.
-        /// </summary>
-        internal PdfReference ReadCompressedObject(PdfObjectID objectID, int index)
-        {
-#if true
-            Debug.Assert(_document.IrefTable.ObjectTable.ContainsKey(objectID));
-            if (!_document.IrefTable.ObjectTable.TryGetValue(objectID, out var iref))
-            {
-                throw new NotImplementedException("This case is not coded or something else went wrong");
-            }
-#else
-            // We should never come here because the object stream must be a type 1 entry in the xref stream
-            // and iref was created before.
-
-            // Has the specified object already an iref in the object table?
-            if (!_document._irefTable.ObjectTable.TryGetValue(objectID, out iref))
-            {
-                try
-                {
-#if true_
-                    iref = new PdfReference(objectID,);
-                    iref.ObjectID = objectID;
-                    _document._irefTable.Add(os);
-#else
-                    PdfDictionary dict = (PdfDictionary)ReadObject(null, objectID, false, false);
-                    PdfObjectStream os = new PdfObjectStream(dict);
-                    iref = new PdfReference(os);
-                    iref.ObjectID = objectID;
-                    _document._irefTable.Add(os);
-#endif
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine(ex.Message);
-                    throw;
-                }
-            }
-#endif
-
-            Debug.Assert(iref.Value != null, "The object shall be read in by PdfReader.ReadIndirectObjectsFromIrefTable() before accessing it.");
-
-            var objectStreamStream = iref.Value as PdfObjectStream;
-            if (objectStreamStream == null)
-            {
-                Debug.Assert(((PdfDictionary)iref.Value).Elements.GetName("/Type") == "/ObjStm");
-
-                objectStreamStream = new PdfObjectStream((PdfDictionary)iref.Value);
-                Debug.Assert(objectStreamStream.Reference == iref);
-                // objectStream.Reference = iref; Superfluous, see Assert in line before.
-                Debug.Assert(objectStreamStream.Reference.Value != null, "Something went wrong.");
-            }
-            Debug.Assert(objectStreamStream != null);
-
-            //PdfObjectStream objectStreamStream = (PdfObjectStream)iref.Value;
-            if (objectStreamStream == null)
-                throw new Exception("Something went wrong here.");
-            return objectStreamStream.ReadCompressedObject(index);
-        }
-
-        /// <summary>
         /// Reads the compressed object with the specified number at the given offset.
-        /// The parser must be initialized with the stream an object stream object.
+        /// The parser must be initialized with the stream of an object stream object.
         /// </summary>
         internal PdfReference ReadCompressedObject(int objectNumber, int offset)
         {
@@ -1111,7 +996,7 @@ namespace PdfSharp.Pdf.IO
                         return trailer;
                     }
                     else
-                        ParserDiagnostics.HandleUnexpectedToken(_lexer.Token);
+                        ParserDiagnostics.HandleUnexpectedToken(_lexer.Token, _lexer.Position - _lexer.Token.Length);
                 }
             }
             // ReSharper disable once RedundantIfElseBlock because of code readability.
@@ -1345,7 +1230,6 @@ namespace PdfSharp.Pdf.IO
 #endif
                                 // Add iref for all uncompressed objects.
                                 xrefTable.Add(new PdfReference(objectID, position));
-
                             }
 #if DEBUG
                             else
@@ -1356,7 +1240,14 @@ namespace PdfSharp.Pdf.IO
                             break;
 
                         case 2:
-                            // Nothing to do yet.
+                            // object-stream number / index in object-stream
+                            // collect irefs for objects stored in object streams
+                            objectID = new PdfObjectID(subsections[ssc][0] + idx, 0);
+                            if (!xrefTable.Contains(objectID))
+                            {
+                                xrefTable.Add(new PdfReferenceToCompressedObject(_document, objectID,
+                                    (int)item.Field2, (int)item.Field3));
+                            }
                             break;
                     }
                 }
@@ -1735,7 +1626,7 @@ namespace PdfSharp.Pdf.IO
             }
         */
 
-        ParserState SaveState()
+        internal ParserState SaveState()
         {
             var state = new ParserState
             {
@@ -1745,13 +1636,13 @@ namespace PdfSharp.Pdf.IO
             return state;
         }
 
-        void RestoreState(ParserState state)
+        internal void RestoreState(ParserState state)
         {
             _lexer.Position = state.Position;
             _lexer.Symbol = state.Symbol;
         }
 
-        class ParserState
+        internal class ParserState
         {
             public int Position;
             public Symbol Symbol;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Security/PdfStandardSecurityHandler.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Security/PdfStandardSecurityHandler.cs
@@ -267,7 +267,15 @@ namespace PdfSharp.Pdf.Security
             switch (value)
             {
                 case PdfDictionary vDict:
-                    DecryptDictionary(vDict);
+                    // this check is required for object-streams
+                    // which may be "lazily" loaded and decrypted in PdfReferenceToCompressedObject.ReadValue
+                    // alternatively we could populate a list of already decrypted objects,
+                    // but this would probably required more memory
+                    if (!vDict.AlreadyDecrypted)
+                    {
+                        DecryptDictionary(vDict);
+                        vDict.AlreadyDecrypted = true;
+                    }
                     break;
                 case PdfArray vArray:
                     DecryptArray(vArray);

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDictionary.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDictionary.cs
@@ -45,6 +45,12 @@ namespace PdfSharp.Pdf
         // Reference: 3.2.6  Dictionary Objects / Page 59
 
         /// <summary>
+        /// Determines, whether this instance was already decrypted.<br></br>
+        /// (in case the document is protected)
+        /// </summary>
+        internal bool AlreadyDecrypted { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PdfDictionary"/> class.
         /// </summary>
         public PdfDictionary()

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -120,6 +120,23 @@ namespace PdfSharp.Pdf
             Trailer.CreateNewDocumentIDs();
         }
 
+        /// <summary>
+        /// Gets a <see cref="Parser"/> for an imported document.<br></br>
+        /// Returns null, if the document was not imported.<br></br>
+        /// If this method is called multiple times for the same document,
+        /// the same parser-instance is returned each time.
+        /// </summary>
+        /// <returns>The parser-instance for imported documents or null when the document was not imported</returns>
+        internal Parser? GetParser()
+        {
+            if (_parser == null)
+            {
+                if (_lexer != null)
+                    _parser = new Parser(this, _lexer);
+            }
+            return _parser;
+        }
+
         //~PdfDocument()
         //{
         //  Dispose(false);
@@ -813,6 +830,7 @@ namespace PdfSharp.Pdf
 
         // Imported Document.
         internal Lexer? _lexer;
+        internal Parser? _parser;
 
         internal DateTime _creation;
 


### PR DESCRIPTION
This PR attempts to resolve the issues described in #73 and #46 in a more generic way.
It also supersedes #53 by removing the need to handle objects stored in object-streams in a special way.

The "lazy loading" aspect is handled by the new class `PdfReferenceToCompressedObject`, which is a sub-class of `PdfReference`.
While processing the document's xref-streams, references to objects stored in object-streams are collected in the form of the mentioned `PdfReferenceToCompressedObject`.
When accessing the `Value` of such a reference (which may occur while parsing another object which contains a reference to the compressed object), the object-stream is loaded and decrypted (if not already done) and the actual object is read from the object-stream.

Have not found any issue so far running automated tests with these changes against ~1000 PDF-files (testing page-import).

Note:
The PR also includes some minor tweaks not directly related to object-loading, which i think are helpful.
(like reporting the position within a document where an unexpected token was encountered during parsing)