### PR TITLE
Fix slowness in decoding hexadecimal string

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Content/CLexer.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Content/CLexer.cs
@@ -607,11 +607,11 @@ namespace PdfSharp.Pdf.Content
                 }
                 if (Char.IsLetterOrDigit(_currChar))
                 {
-                    hex[0] = Char.ToUpper(_currChar);
+                    hex[0] = _currChar;
                     // Second char is optional in PDF spec.
                     if (Char.IsLetterOrDigit(_nextChar))
                     {
-                        hex[1] = Char.ToUpper(_nextChar);
+                        hex[1] = _nextChar;
                         ScanNextChar();
                     }
                     else

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Lexer.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Lexer.cs
@@ -684,11 +684,11 @@ namespace PdfSharp.Pdf.IO
                 }
                 if (Char.IsLetterOrDigit(_currChar))
                 {
-                    hex[0] = Char.ToUpper(_currChar);
+                    hex[0] = _currChar;
                     // Second char is optional in PDF spec.
                     if (Char.IsLetterOrDigit(_nextChar))
                     {
-                        hex[1] = Char.ToUpper(_nextChar);
+                        hex[1] = _nextChar;
                         ScanNextChar(true);
                     }
                     else


### PR DESCRIPTION
`Char` methods are Unicode compliant, and `Char.ToUpper()` is really slow probably because of it.
On my test, while English text PDFs aren't visibly affected, Japanese ones are.

The PR removes `Char.ToUpper()` calls since `AllowHexSpecifier` supports lowercase characters.