### PR TITLE
Add optional point argument to AddDocumentLink

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Annotations/PdfLinkAnnotation.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Annotations/PdfLinkAnnotation.cs
@@ -4,6 +4,7 @@
 using PdfSharp.Pdf.Actions;
 using PdfSharp.Pdf.IO;
 using PdfSharp.Pdf.Internal;
+using PdfSharp.Drawing;
 
 namespace PdfSharp.Pdf.Annotations
 {
@@ -42,7 +43,8 @@ namespace PdfSharp.Pdf.Annotations
         /// </summary>
         /// <param name="rect">The link area in default page coordinates.</param>
         /// <param name="destinationPage">The one-based destination page number.</param>
-        public static PdfLinkAnnotation CreateDocumentLink(PdfRectangle rect, int destinationPage)
+        /// <param name="point">The position in the destination page.</param>
+        public static PdfLinkAnnotation CreateDocumentLink(PdfRectangle rect, int destinationPage, XPoint? point = null)
         {
             if (destinationPage < 1)
                 throw new ArgumentException("Invalid destination page in call to CreateDocumentLink: page number is one-based and must be 1 or higher.", nameof(destinationPage));
@@ -51,12 +53,14 @@ namespace PdfSharp.Pdf.Annotations
             link._linkType = LinkType.Document;
             link.Rectangle = rect;
             link._destPage = destinationPage;
+            link._point = point;
             return link;
         }
 
         int _destPage;
         LinkType _linkType;
         string _url = "";
+        XPoint? _point = null;
 
         /// <summary>
         /// Creates a link within the current document using a named destination.
@@ -195,8 +199,15 @@ namespace PdfSharp.Pdf.Annotations
                         destIndex = Owner.PageCount;
                     destIndex--;
                     dest = Owner.Pages[destIndex];
-                    //pdf.AppendFormat("/Dest[{0} 0 R/XYZ null null 0]\n", dest.ObjectID);
-                    Elements[Keys.Dest] = new PdfLiteral("[{0} 0 R/XYZ null null 0]", dest.ObjectNumber);
+                    //pdf.AppendFormat("/Dest[{0} 0 R /XYZ null null 0]\n", dest.ObjectID);
+                    if (_point.HasValue)
+                    {
+                        Elements[Keys.Dest] = new PdfLiteral("[{0} 0 R /XYZ {1} {2} 0]", dest.ObjectNumber, _point.Value.X, _point.Value.Y);
+                    }
+                    else
+                    {
+                        Elements[Keys.Dest] = new PdfLiteral("[{0} 0 R /XYZ null null 0]", dest.ObjectNumber);
+                    }
                     break;
 
                 case LinkType.NamedDestination:

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfPage.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfPage.cs
@@ -403,9 +403,10 @@ namespace PdfSharp.Pdf
         /// </summary>
         /// <param name="rect">The link area in default page coordinates.</param>
         /// <param name="destinationPage">The destination page.</param>
-        public PdfLinkAnnotation AddDocumentLink(PdfRectangle rect, int destinationPage)
+        /// <param name="point">The position in the destination page.</param>
+        public PdfLinkAnnotation AddDocumentLink(PdfRectangle rect, int destinationPage, XPoint? point = null)
         {
-            var annotation = PdfLinkAnnotation.CreateDocumentLink(rect, destinationPage);
+            var annotation = PdfLinkAnnotation.CreateDocumentLink(rect, destinationPage, point);
             Annotations.Add(annotation);
             return annotation;
         }


### PR DESCRIPTION
I was adding table of contents to a generated document and realized that PDFSharp's document links only go to a destination page, but PDF supports going to specific locations within that page.  Proposed is the addition of an optional argument to include a target point if desired.