### PR TITLE
Support glyph-colors (e.g. Emojis)

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/OpenTypeDescriptor.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/OpenTypeDescriptor.cs
@@ -503,6 +503,7 @@ namespace PdfSharp.Fonts.OpenType
                     // Remap ch for symbol fonts.
                     item.CodePoint = codePoint;
                     item.GlyphIndex = BmpCodepointToGlyphIndex(ch);
+                    item.Color = GetColorRecord(item.GlyphIndex);
                 }
             }
             else
@@ -532,6 +533,7 @@ namespace PdfSharp.Fonts.OpenType
                     item.GlyphIndex = item.CodePoint < UnicodeHelper.UnicodePlane01Start
                         ? BmpCodepointToGlyphIndex((char)item.CodePoint)
                         : CodepointToGlyphIndex(item.CodePoint);
+                    item.Color = GetColorRecord(item.GlyphIndex);
                 }
             }
             return result;
@@ -558,6 +560,22 @@ namespace PdfSharp.Fonts.OpenType
 
             // Used | instead of + because of: http://pdfsharp.codeplex.com/workitem/15954
             return (char)(ch | (FontFace.os2.usFirstCharIndex & 0xFF00));
+        }
+
+        /// <summary>
+        /// Gets the color-record of the glyph with the specified id
+        /// </summary>
+        /// <param name="glyphId"></param>
+        /// <returns>The color-record for the specified glyph or null, if the specified glyph has no color record</returns>
+        public ColrTable.GlyphRecord? GetColorRecord(int glyphId)
+        {
+            // both tables are required according to the spec
+            // ref: https://learn.microsoft.com/en-us/typography/opentype/spec/colr
+            if (FontFace.cpal != null && FontFace.colr != null)
+            {
+                return FontFace.colr.GetLayers(glyphId);
+            }
+            return null;
         }
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/OpenTypeFontface.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/OpenTypeFontface.cs
@@ -162,6 +162,8 @@ namespace PdfSharp.Fonts.OpenType
         // ReSharper disable InconsistentNaming
         // ReSharper disable IdentifierTypo
         internal CMapTable cmap = default!; // NRT TODO Change programming model so that it fits NRTs.
+        internal ColrTable? colr = default;
+        internal CpalTable? cpal = default;
         internal ControlValueTable cvt = default!; // NRT
         internal FontProgram fpgm = default!; // NRT
         internal MaximumProfileTable maxp = default!; // NRT
@@ -334,6 +336,12 @@ namespace PdfSharp.Fonts.OpenType
                 // Read required tables.
                 if (Seek(CMapTable.Tag) != -1)
                     cmap = new CMapTable(this);
+
+                if (Seek(ColrTable.Tag) != -1)
+                    colr = new ColrTable(this);
+
+                if (Seek(CpalTable.Tag) != -1)
+                    cpal = new CpalTable(this);
 
                 if (Seek(ControlValueTable.Tag) != -1)
                     cvt = new ControlValueTable(this);

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/enums/TableTagNames.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/enums/TableTagNames.cs
@@ -181,5 +181,15 @@ namespace PdfSharp.Fonts.OpenType
         /// Vertical Metrics.
         /// </summary>
         public const string VMtx = "vmtx";
+
+        /// <summary>
+        /// Color table
+        /// </summary>
+        public const string COLR = "COLR";
+
+        /// <summary>
+        /// Color palette table
+        /// </summary>
+        public const string CPAL = "CPAL";
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Fonts/CodePointGlyphIndexPair.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Fonts/CodePointGlyphIndexPair.cs
@@ -1,6 +1,8 @@
 ﻿// PDFsharp - A .NET library for processing PDF
 // See the LICENSE file in the solution root for more information.
 
+using PdfSharp.Fonts.OpenType;
+
 namespace PdfSharp.Fonts
 {
     /// <summary>
@@ -20,5 +22,10 @@ namespace PdfSharp.Fonts
         /// The value is 0 if the specific font has no glyph for the code point.
         /// </summary>
         public ushort GlyphIndex = glyphIndex;
+
+        /// <summary>
+        /// The color-record of the Glyph if provided by the font.
+        /// </summary>
+        internal ColrTable.GlyphRecord? Color = null;
     }
 }

--- a/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/ApplicationFontResolver.cs
+++ b/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/ApplicationFontResolver.cs
@@ -1,0 +1,101 @@
+﻿using PdfSharp.Fonts;
+
+namespace PdfSharp.Tests
+{
+    /// <summary>
+    /// Used to resolve application-specific fonts
+    /// </summary>
+    public class ApplicationFontResolver : IFontResolver
+    {
+        private readonly Dictionary<string, byte[]> localFonts = [];
+        private readonly List<string> searchPaths = [];
+
+        /// <summary>
+        /// Registers a new font
+        /// </summary>
+        /// <param name="fontName">The name of the font</param>
+        /// <param name="fontData">The font-data</param>
+        /// <param name="isBold">Specifies, whether the font is bold</param>
+        /// <param name="isItalic">Specifies, whether the font is italic</param>
+        public void Register(string fontName, byte[] fontData, bool isBold = false, bool isItalic = false)
+        {
+            var localName = MakeLocalName(fontName, isBold, isItalic);
+            localFonts[localName] = fontData;
+        }
+
+        /// <summary>
+        /// Registers a path in the file-system where the resolver should look for fonts
+        /// </summary>
+        /// <param name="path"></param>
+        public void RegisterSearchPath(string path)
+        {
+            if (!searchPaths.Contains(path))
+            {
+                searchPaths.Add(path);
+            }
+        }
+
+        /// <summary>
+        /// Gets the data for the specified font.
+        /// </summary>
+        /// <param name="faceName">Name of the font</param>
+        /// <returns>Font data or null, if no font with the specified name could be found</returns>
+        public byte[]? GetFont(string faceName)
+        {
+            var result = Resolve(faceName, false, false);
+            return result.Item1;
+        }
+
+        /// <summary>
+        /// Get a <see cref="FontResolverInfo"/> for the specified font
+        /// </summary>
+        /// <param name="familyName">Name of the font</param>
+        /// <param name="isBold"></param>
+        /// <param name="isItalic"></param>
+        /// <returns>A <see cref="FontResolverInfo"/> or null, if no font with the specified name could be found</returns>
+        public FontResolverInfo? ResolveTypeface(string familyName, bool isBold, bool isItalic)
+        {
+            var result = Resolve(familyName, isBold, isItalic);
+            return result.Item2;
+        }
+
+        private byte[]? GetFontFromFile(string faceName)
+        {
+            foreach (var fontLocation in searchPaths)
+            {
+                var filepath = Path.Combine(fontLocation, faceName + ".ttf");
+                if (File.Exists(filepath))
+                    return File.ReadAllBytes(filepath);
+            }
+
+            return null;
+        }
+
+        private static string MakeLocalName(string fontName, bool isBold, bool isItalic)
+        {
+            var localName = fontName;
+            if (isBold || isItalic)
+            {
+                localName += "+";
+                if (isBold)
+                    localName += "b";
+                if (isItalic)
+                    localName += "i";
+            }
+            return localName;
+        }
+
+        private Tuple<byte[]?, FontResolverInfo?> Resolve(string fontName, bool isBold, bool isItalic)
+        {
+            var localName = MakeLocalName(fontName, isBold, isItalic);
+            if (localFonts.TryGetValue(localName, out var localData))
+                return new Tuple<byte[]?, FontResolverInfo?>(localData, new FontResolverInfo(fontName));
+
+            localData = GetFontFromFile(fontName);
+            if (localData != null)
+                return new Tuple<byte[]?, FontResolverInfo?>(localData, new FontResolverInfo(fontName));
+
+            return new Tuple<byte[]?, FontResolverInfo?>(null, null);
+        }
+    }
+}

--- a/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/TextTests.cs
+++ b/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/TextTests.cs
@@ -17,9 +17,26 @@ namespace PdfSharp.Tests
     [Collection("PDFsharp")]
     public class TextTests
     {
-        [Fact(Skip = "Need Segoe UI Emoji here")]
-        public void PDF_with_Emojis()
+        [Theory]
+        [InlineData(@"C:\Windows\Fonts\seguiemj.ttf")]
+        public void PDF_with_Emojis(string fontPath)
         {
+            File.Exists(fontPath).Should().BeTrue();
+
+            var fontName = Path.GetFileNameWithoutExtension(fontPath);
+
+            var fontResolver = new ApplicationFontResolver();
+            var fontLocations = new List<string>
+            {
+                @"C:\Windows\Fonts"
+            };
+            foreach (var fontLocation in fontLocations)
+            {
+                fontResolver.RegisterSearchPath(fontLocation);
+            }
+            GlobalFontSettings.FontResolver = fontResolver;
+
+
             // Create a new PDF document.
             var document = new PdfDocument();
             document.Info.Title = "Created with PDFsharp";
@@ -35,13 +52,13 @@ namespace PdfSharp.Tests
             var width = page.Width.Point;
             var height = page.Height.Point;
 
-            XPdfFontOptions options = new XPdfFontOptions(PdfFontEncoding.Unicode);
-            XFont font = new XFont("Segoe UI Emoji", 12, XFontStyleEx.Regular, options);
-            gfx.DrawString("111😢😞💪", font, XBrushes.Black, new XRect(0, 0, width, height), XStringFormats.Center);
+            var options = new XPdfFontOptions(PdfFontEncoding.Unicode);
+            var font = new XFont(fontName, 12, XFontStyleEx.Regular, options);
+            gfx.DrawString("111 😢X😞X💪 111", font, XBrushes.Black, new XRect(0, 0, width, height), XStringFormats.Center);
             gfx.DrawString("\ud83d\udca9\ud83d\udca9\ud83d\udca9\u2713\u2714\u2705\ud83d\udc1b\ud83d\udc4c\ud83c\udd97\ud83d\udd95 \ud83e\udd84 \ud83e\udd82 \ud83c\udf47 \ud83c\udf46 \u2615 \ud83d\ude82 \ud83d\udef8 \u2601 \u2622 \u264c \u264f \u2705 \u2611 \u2714 \u2122 \ud83c\udd92 \u25fb", font, XBrushes.Black, new XRect(0, 50, width, height), XStringFormats.Center);
 
             // Save the document...
-            string filename = PdfFileUtility.GetTempPdfFileName("HelloEmoji");
+            string filename = Path.Combine(Path.GetTempPath(), "HelloEmoji.pdf");
             document.Save(filename);
             // ...and start a viewer.
             PdfFileUtility.ShowDocumentIfDebugging(filename);


### PR DESCRIPTION
This PR adds support for glyph-colors specified in certain fonts, for example `Segoe UI Emoji`.

For demo-purposes i slightly adapted the existing test case `TextTests.PDF_with_Emojis`

Result before changes:
![image](https://github.com/empira/PDFsharp/assets/38851536/9a268c4c-22f8-4532-a664-d7534c5bdc6e)

Result after changes:
![image](https://github.com/empira/PDFsharp/assets/38851536/639474a0-a6be-41ba-8be5-a2d87ab23a50)
