### PR TITLE
Used `nameof()` instead of string literals in places where it was needed

### DIFF
--- a/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Fields/BookmarkField.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Fields/BookmarkField.cs
@@ -55,7 +55,7 @@ namespace MigraDoc.DocumentObjectModel.Fields
         internal override void Serialize(Serializer serializer)
         {
             if (String.IsNullOrEmpty(Values.Name))
-                throw new InvalidOperationException(DomSR.MissingObligatoryProperty("Name", "BookmarkField"));
+                throw new InvalidOperationException(DomSR.MissingObligatoryProperty(nameof(Name), nameof(BookmarkField)));
 
             serializer.Write("\\field(Bookmark)[Name = \"" + Name.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"]");
         }

--- a/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Fields/InfoField.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel.Fields/InfoField.cs
@@ -73,9 +73,11 @@ namespace MigraDoc.DocumentObjectModel.Fields
         /// </summary>
         internal override void Serialize(Serializer serializer)
         {
-            string str = "\\field(Info)";
             if (Name == "")
-                throw new InvalidOperationException(DomSR.MissingObligatoryProperty("Name", "InfoField"));
+                throw new InvalidOperationException(DomSR.MissingObligatoryProperty(nameof(Name), nameof(InfoField)));
+
+            string str = "\\field(Info)";
+
             str += "[Name = \"" + Name + "\"]";
 
             serializer.Write(str);

--- a/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel/Borders.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel/Borders.cs
@@ -33,7 +33,7 @@ namespace MigraDoc.DocumentObjectModel
         public bool HasBorder(BorderType type)
         {
             if (!Enum.IsDefined(typeof(BorderType), type))
-                throw new /*InvalidEnum*/ArgumentException(DomSR.InvalidEnumValue(type), "type");
+                throw new /*InvalidEnum*/ArgumentException(DomSR.InvalidEnumValue(type), nameof(type));
 
             return GetBorder(type) is not null;
         }

--- a/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel/Hyperlink.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.DocumentObjectModel/DocumentObjectModel/Hyperlink.cs
@@ -581,14 +581,14 @@ namespace MigraDoc.DocumentObjectModel
             if (Type is HyperlinkType.ExternalBookmark or HyperlinkType.File or HyperlinkType.Url)
             {
                 if (String.IsNullOrEmpty(Values.Filename))
-                    throw new InvalidOperationException(DomSR.MissingObligatoryProperty("Filename", $"Hyperlink {Type.ToString()}"));
+                    throw new InvalidOperationException(DomSR.MissingObligatoryProperty(nameof(Filename), $"Hyperlink {Type.ToString()}"));
 
                 str += " Filename = \"" + Filename.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
             }
             if (Type is HyperlinkType.ExternalBookmark or HyperlinkType.Bookmark or HyperlinkType.EmbeddedDocument)
             {
                 if (String.IsNullOrEmpty(Values.BookmarkName))
-                    throw new InvalidOperationException(DomSR.MissingObligatoryProperty("BookmarkName", $"Hyperlink {Type.ToString()}"));
+                    throw new InvalidOperationException(DomSR.MissingObligatoryProperty(nameof(BookmarkName), $"Hyperlink {Type.ToString()}"));
 
                 str += " BookmarkName = \"" + BookmarkName.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
             }

--- a/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/PdfDocumentRenderer.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/PdfDocumentRenderer.cs
@@ -94,7 +94,7 @@ namespace MigraDoc.Rendering
         void PrepareDocumentRenderer(bool prepareCompletely)
         {
             if (_document == null)
-                throw new InvalidOperationException(Messages2.PropertyNotSetBefore("DocumentRenderer", MethodBase.GetCurrentMethod()!.Name));
+                throw new InvalidOperationException(Messages2.PropertyNotSetBefore(nameof(DocumentRenderer), MethodBase.GetCurrentMethod()!.Name));
 
             _documentRenderer ??= new(_document)
             {

--- a/src/foundation/src/MigraDoc/src/MigraDoc.RtfRendering/RtfRendering/RtfDocumentRenderer.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.RtfRendering/RtfRendering/RtfDocumentRenderer.cs
@@ -1,14 +1,14 @@
 ﻿// MigraDoc - Creating Documents on the Fly
 // See the LICENSE file in the solution root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 using MigraDoc.DocumentObjectModel;
 using MigraDoc.DocumentObjectModel.Internals;
 using MigraDoc.DocumentObjectModel.Visitors;
 using PdfSharp.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
 using Color = MigraDoc.DocumentObjectModel.Color;
 using Font = MigraDoc.DocumentObjectModel.Font;
 
@@ -96,7 +96,8 @@ namespace MigraDoc.RtfRendering
         public void Render(Document document, Stream stream, bool closeStream, string workingDirectory)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
+
             if (document.UseCmykColor)
                 throw new InvalidOperationException("Cannot create RTF document with CMYK colors.");
 
@@ -138,7 +139,8 @@ namespace MigraDoc.RtfRendering
         public string RenderToString(Document document, string workingDirectory)
         {
             if (document == null)
-                throw new ArgumentNullException("document");
+                throw new ArgumentNullException(nameof(document));
+
             if (document.UseCmykColor)
                 throw new InvalidOperationException("Cannot create RTF document with CMYK colors.");
 
@@ -169,7 +171,7 @@ namespace MigraDoc.RtfRendering
             if (Document.EmbeddedFiles.Count > 0)
                 throw new InvalidOperationException("Embedded files are not supported in RTF documents.");
 
-            RtfFlattenVisitor flattener = new RtfFlattenVisitor();
+            RtfFlattenVisitor flattener = new();
             flattener.Visit(_document);
             Prepare();
             _rtfWriter.StartContent();
@@ -280,7 +282,7 @@ namespace MigraDoc.RtfRendering
             for (int idx = 0; idx < _fontList.Count; ++idx)
             {
                 _rtfWriter.StartContent();
-                string name = (string)_fontList[idx];
+                string name = _fontList[idx];
                 _rtfWriter.WriteControl("f", idx);
 #if true
                 //System.Drawing.Font font = new System.Drawing.Font(name, 12); //any size
@@ -311,9 +313,8 @@ namespace MigraDoc.RtfRendering
             //this would indicate index 0 as auto color:
             //this.rtfWriter.WriteSeparator();
             //left away cause there is no auto color in MigraDoc.
-            foreach (var obj in _colorList)
+            foreach (var color in _colorList)
             {
-                Color color = (Color)obj;
                 _rtfWriter.WriteControl("red", (int)color.R);
                 _rtfWriter.WriteControl("green", (int)color.G);
                 _rtfWriter.WriteControl("blue", (int)color.B);
@@ -328,10 +329,10 @@ namespace MigraDoc.RtfRendering
         internal int GetFontIndex(string fontName)
         {
             if (_fontList.Contains(fontName))
-                return (int)_fontList.IndexOf(fontName);
+                return _fontList.IndexOf(fontName);
 
             //development purpose exception
-            throw new ArgumentException(@"Font does not exist in this document’s font table.", "fontName");
+            throw new ArgumentException(@"Font does not exist in this document’s font table.", nameof(fontName));
         }
 
         /// <summary>
@@ -340,10 +341,10 @@ namespace MigraDoc.RtfRendering
         internal int GetColorIndex(Color color)
         {
             Color clr = color.GetMixedTransparencyColor();
-            int idx = (int)_colorList.IndexOf(clr);
+            int idx = _colorList.IndexOf(clr);
             // Development purpose exception.
             if (idx < 0)
-                throw new ArgumentException(@"Color does not exist in this document’s color table.", "color");
+                throw new ArgumentException(@"Color does not exist in this document’s color table.", nameof(color));
             return idx;
         }
 
@@ -380,21 +381,18 @@ namespace MigraDoc.RtfRendering
 
             _rtfWriter.StartContent();
             _rtfWriter.WriteControlWithStar("listtable");
-            foreach (var obj in _listList)
+            foreach (var lst in _listList)
             {
-                ListInfo lst = (ListInfo)obj;
-                ListInfoRenderer lir = new ListInfoRenderer(lst, this);
+                ListInfoRenderer lir = new(lst, this);
                 lir.Render();
             }
             _rtfWriter.EndContent();
 
             _rtfWriter.StartContent();
             _rtfWriter.WriteControlWithStar("listoverridetable");
-            foreach (var obj in _listList)
+            foreach (var lst in _listList)
             {
-                ListInfo lst = (ListInfo)obj;
-                ListInfoOverrideRenderer lir =
-                    new ListInfoOverrideRenderer(lst, this);
+                ListInfoOverrideRenderer lir = new(lst, this);
                 lir.Render();
             }
             _rtfWriter.EndContent();
@@ -517,9 +515,7 @@ namespace MigraDoc.RtfRendering
         /// Gets the MigraDoc document that is currently rendered.
         /// </summary>
         internal Document Document
-        {
-            get { return _document; }
-        }
+            => _document;
 
         Document _document = null!;
 
@@ -527,18 +523,15 @@ namespace MigraDoc.RtfRendering
         /// Gets the RtfWriter the document is rendered with.
         /// </summary>
         internal RtfWriter RtfWriter
-        {
-            get { return _rtfWriter; }
-        }
+            => _rtfWriter;
 
         internal string WorkingDirectory
-        {
-            get { return _workingDirectory; }
-        }
+            => _workingDirectory;
+        
         string _workingDirectory = null!;
 
-        readonly List<Color> _colorList = new List<Color>();
-        readonly List<string> _fontList = new List<string>();
-        readonly List<ListInfo> _listList = new List<ListInfo>();
+        readonly List<Color> _colorList = new();
+        readonly List<string> _fontList = new();
+        readonly List<ListInfo> _listList = new();
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Drawing/XGraphics.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Drawing/XGraphics.cs
@@ -1155,11 +1155,11 @@ namespace PdfSharp.Drawing  // #??? Clean up
         public void DrawLines(XPen pen, GdiPointF[] points)
         {
             if (pen == null)
-                throw new ArgumentNullException("pen");
+                throw new ArgumentNullException(nameof(pen));
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
             if (points.Length < 2)
-                throw new ArgumentException(PSSR.PointArrayAtLeast(2), "points");
+                throw new ArgumentException(PSSR.PointArrayAtLeast(2), nameof(points));
 
             if (_drawGraphics)
             {
@@ -1914,9 +1914,9 @@ namespace PdfSharp.Drawing  // #??? Clean up
         public void DrawRectangles(XPen pen, GdiRect[] rectangles)
         {
             if (pen == null)
-                throw new ArgumentNullException("pen");
+                throw new ArgumentNullException(nameof(pen));
             if (rectangles == null)
-                throw new ArgumentNullException("rectangles");
+                throw new ArgumentNullException(nameof(rectangles));
 
             DrawRectangles(pen, null, rectangles);
         }
@@ -1929,9 +1929,9 @@ namespace PdfSharp.Drawing  // #??? Clean up
         public void DrawRectangles(XPen pen, GdiRectF[] rectangles)
         {
             if (pen == null)
-                throw new ArgumentNullException("pen");
+                throw new ArgumentNullException(nameof(pen));
             if (rectangles == null)
-                throw new ArgumentNullException("rectangles");
+                throw new ArgumentNullException(nameof(rectangles));
 
             DrawRectangles(pen, null, rectangles);
         }
@@ -1959,9 +1959,9 @@ namespace PdfSharp.Drawing  // #??? Clean up
         public void DrawRectangles(XBrush brush, GdiRect[] rectangles)
         {
             if (brush == null)
-                throw new ArgumentNullException("brush");
+                throw new ArgumentNullException(nameof(brush));
             if (rectangles == null)
-                throw new ArgumentNullException("rectangles");
+                throw new ArgumentNullException(nameof(rectangles));
 
             DrawRectangles(null, brush, rectangles);
         }
@@ -1974,9 +1974,9 @@ namespace PdfSharp.Drawing  // #??? Clean up
         public void DrawRectangles(XBrush brush, GdiRectF[] rectangles)
         {
             if (brush == null)
-                throw new ArgumentNullException("brush");
+                throw new ArgumentNullException(nameof(brush));
             if (rectangles == null)
-                throw new ArgumentNullException("rectangles");
+                throw new ArgumentNullException(nameof(rectangles));
 
             DrawRectangles(null, brush, rectangles);
         }
@@ -2006,7 +2006,7 @@ namespace PdfSharp.Drawing  // #??? Clean up
             if (pen == null && brush == null)
                 throw new ArgumentNullException("pen and brush", PSSR.NeedPenOrBrush);
             if (rectangles == null)
-                throw new ArgumentNullException("rectangles");
+                throw new ArgumentNullException(nameof(rectangles));
 
             if (_drawGraphics)
             {
@@ -2041,7 +2041,7 @@ namespace PdfSharp.Drawing  // #??? Clean up
             if (pen == null && brush == null)
                 throw new ArgumentNullException("pen and brush", PSSR.NeedPenOrBrush);
             if (rectangles == null)
-                throw new ArgumentNullException("rectangles");
+                throw new ArgumentNullException(nameof(rectangles));
 
             if (_drawGraphics)
             {

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Drawing/XMatrix.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Drawing/XMatrix.cs
@@ -400,7 +400,7 @@ namespace PdfSharp.Drawing
         /// </summary>
         public void RotateAppend(double angle) // TODO: will become default Rotate
         {
-            angle = angle % 360.0;
+            angle %= 360.0;
             this *= CreateRotationRadians(angle * Const.Deg2Rad);
         }
 
@@ -409,7 +409,7 @@ namespace PdfSharp.Drawing
         /// </summary>
         public void RotatePrepend(double angle)
         {
-            angle = angle % 360.0;
+            angle %= 360.0;
             this = CreateRotationRadians(angle * Const.Deg2Rad) * this;
         }
 
@@ -421,7 +421,7 @@ namespace PdfSharp.Drawing
             if (_type == XMatrixTypes.Identity)
                 this = CreateIdentity();
 
-            angle = angle * Const.Deg2Rad;
+            angle *= Const.Deg2Rad;
             double cos = Math.Cos(angle);
             double sin = Math.Sin(angle);
             if (order == XMatrixOrder.Append)
@@ -472,7 +472,7 @@ namespace PdfSharp.Drawing
         /// </summary>
         public void RotateAtAppend(double angle, double centerX, double centerY) // TODO: will become default
         {
-            angle = angle % 360.0;
+            angle %= 360.0;
             this *= CreateRotationRadians(angle * Const.Deg2Rad, centerX, centerY);
         }
 
@@ -481,7 +481,7 @@ namespace PdfSharp.Drawing
         /// </summary>
         public void RotateAtPrepend(double angle, double centerX, double centerY)
         {
-            angle = angle % 360.0;
+            angle %= 360.0;
             this = CreateRotationRadians(angle * Const.Deg2Rad, centerX, centerY) * this;
         }
 
@@ -520,7 +520,7 @@ namespace PdfSharp.Drawing
         {
             if (order == XMatrixOrder.Append)
             {
-                angle = angle % 360.0;
+                angle %= 360.0;
                 this *= CreateRotationRadians(angle * Const.Deg2Rad, point.X, point.Y);
 
                 //Translate(point.X, point.Y, order);
@@ -529,7 +529,7 @@ namespace PdfSharp.Drawing
             }
             else
             {
-                angle = angle % 360.0;
+                angle %= 360.0;
                 this = CreateRotationRadians(angle * Const.Deg2Rad, point.X, point.Y) * this;
             }
 
@@ -614,8 +614,8 @@ namespace PdfSharp.Drawing
         /// </summary>
         public void SkewAppend(double skewX, double skewY)
         {
-            skewX = skewX % 360.0;
-            skewY = skewY % 360.0;
+            skewX %= 360.0;
+            skewY %= 360.0;
             this *= CreateSkewRadians(skewX * Const.Deg2Rad, skewY * Const.Deg2Rad);
         }
 
@@ -624,8 +624,8 @@ namespace PdfSharp.Drawing
         /// </summary>
         public void SkewPrepend(double skewX, double skewY)
         {
-            skewX = skewX % 360.0;
-            skewY = skewY % 360.0;
+            skewX %= 360.0;
+            skewY %= 360.0;
             this = CreateSkewRadians(skewX * Const.Deg2Rad, skewY * Const.Deg2Rad) * this;
         }
 
@@ -687,7 +687,7 @@ namespace PdfSharp.Drawing
         public void TransformPoints(System.Drawing.Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
 
             if (IsIdentity)
                 return;
@@ -710,7 +710,7 @@ namespace PdfSharp.Drawing
         public void TransformPoints(System.Windows.Point[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
 
             if (IsIdentity)
                 return;
@@ -764,7 +764,7 @@ namespace PdfSharp.Drawing
         public void TransformVectors(PointF[] points)
         {
             if (points == null)
-                throw new ArgumentNullException("points");
+                throw new ArgumentNullException(nameof(points));
 
             if (IsIdentity)
                 return;
@@ -1142,7 +1142,7 @@ namespace PdfSharp.Drawing
         public static XMatrix Parse(string source)
         {
             IFormatProvider cultureInfo = CultureInfo.InvariantCulture; //.GetCultureInfo("en-us");
-            TokenizerHelper helper = new TokenizerHelper(source, cultureInfo);
+            TokenizerHelper helper = new(source, cultureInfo);
             var str = helper.NextTokenRequired();
             XMatrix identity = str == "Identity"
                 ? Identity
@@ -1254,7 +1254,7 @@ namespace PdfSharp.Drawing
 
         internal static XMatrix CreateTranslation(double offsetX, double offsetY)
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new();
             matrix.SetMatrix(1, 0, 0, 1, offsetX, offsetY, XMatrixTypes.Translation);
             return matrix;
         }
@@ -1266,7 +1266,7 @@ namespace PdfSharp.Drawing
 
         internal static XMatrix CreateRotationRadians(double angle, double centerX, double centerY)
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new();
             double sin = Math.Sin(angle);
             double cos = Math.Cos(angle);
             double offsetX = (centerX * (1.0 - cos)) + (centerY * sin);
@@ -1277,14 +1277,14 @@ namespace PdfSharp.Drawing
 
         internal static XMatrix CreateScaling(double scaleX, double scaleY)
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new();
             matrix.SetMatrix(scaleX, 0, 0, scaleY, 0, 0, XMatrixTypes.Scaling);
             return matrix;
         }
 
         internal static XMatrix CreateScaling(double scaleX, double scaleY, double centerX, double centerY)
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new();
             matrix.SetMatrix(scaleX, 0, 0, scaleY, centerX - scaleX * centerX, centerY - scaleY * centerY,
                 XMatrixTypes.Scaling | XMatrixTypes.Translation);
             return matrix;
@@ -1292,7 +1292,7 @@ namespace PdfSharp.Drawing
 
         internal static XMatrix CreateSkewRadians(double skewX, double skewY, double centerX, double centerY)
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new();
             matrix.Append(CreateTranslation(-centerX, -centerY));
             matrix.Append(new XMatrix(1, Math.Tan(skewY), Math.Tan(skewX), 1, 0, 0));
             matrix.Append(CreateTranslation(centerX, centerY));
@@ -1301,14 +1301,14 @@ namespace PdfSharp.Drawing
 
         internal static XMatrix CreateSkewRadians(double skewX, double skewY)
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new ();
             matrix.SetMatrix(1, Math.Tan(skewY), Math.Tan(skewX), 1, 0, 0, XMatrixTypes.Unknown);
             return matrix;
         }
 
         static XMatrix CreateIdentity()
         {
-            XMatrix matrix = new XMatrix();
+            XMatrix matrix = new();
             matrix.SetMatrix(1, 0, 0, 1, 0, 0, XMatrixTypes.Identity);
             return matrix;
         }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Windows/VisualPresenter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Windows/VisualPresenter.cs
@@ -29,9 +29,7 @@ namespace PdfSharp.Windows
         /// Gets the number of visual child elements within this element.
         /// </summary>
         protected override int VisualChildrenCount
-        {
-            get { return _children.Count; }
-        }
+            => _children.Count;
 
         /// <summary>
         /// Overrides <see cref="M:System.Windows.Media.Visual.GetVisualChild(System.Int32)"/>, and returns a child at the specified index from a collection of child elements.
@@ -39,7 +37,7 @@ namespace PdfSharp.Windows
         protected override Visual GetVisualChild(int index)
         {
             if (index < 0 || index >= _children.Count)
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
 
             return _children[index];
         }
@@ -48,9 +46,8 @@ namespace PdfSharp.Windows
         /// Gets the children collection.
         /// </summary>
         public VisualCollection Children
-        {
-            get { return _children; }
-        }
+            => _children;
+
         readonly VisualCollection _children;
     }
 }


### PR DESCRIPTION
Along the way, in the files touched by this change, minor refactorings (like reordering of `using` statements reordering and syntax modernizing) were made.