### PR TITLE
Improve resilience against malformed or corrupt documents

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfTrailer.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfTrailer.cs
@@ -321,7 +321,7 @@ namespace PdfSharp.Pdf.Advanced
                 {
                     // cases:
                     // 1. no trailer found (maybe cut off at end of file)
-                    // 2. trailer is corrupt (found one with just a single /Size entry, /Catalog was missing)
+                    // 2. trailer is corrupt (found one with just a single /Size entry, /Root was missing)
                     // read all found objects searching for the catalog (/Root entry)
                     foreach (var objRef in allRefs)
                     {

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
@@ -57,7 +57,7 @@ namespace PdfSharp.Pdf.IO
         /// </summary>
         /// <param name="objectID">The ID of the object to move.</param>
         /// <param name="suppressObjectOrderExceptions">Suppresses exceptions that may be caused by not yet available objects.</param>
-        public SizeType MoveToObject(PdfObjectID objectID, SuppressExceptions? suppressObjectOrderExceptions)
+        public SizeType MoveToObject(PdfObjectID objectID, SuppressExceptions? suppressObjectOrderExceptions = null)
         {
             SizeType? position = _document.IrefTable[objectID]?.Position;
             if (!position.HasValue)
@@ -829,7 +829,7 @@ namespace PdfSharp.Pdf.IO
         /// <summary>
         /// Reads the next symbol that must be the specified one.
         /// </summary>
-        Symbol ReadSymbol(Symbol symbol)
+        internal Symbol ReadSymbol(Symbol symbol)
         {
             Symbol current = ScanNextToken(symbol == Symbol.ObjRef);
             if (symbol != current)
@@ -903,7 +903,7 @@ namespace PdfSharp.Pdf.IO
         /// <summary>
         /// Reads the PdfObject of the reference, no matter if it’s saved at document level or inside an ObjectStream.
         /// </summary>
-        internal PdfObject ReadIndirectObject(PdfReference pdfReference, SuppressExceptions? suppressObjectOrderExceptions, bool withoutDecrypting = false)
+        internal PdfObject ReadIndirectObject(PdfReference pdfReference, SuppressExceptions? suppressObjectOrderExceptions = null, bool withoutDecrypting = false)
         {
             try
             {
@@ -1406,7 +1406,7 @@ namespace PdfSharp.Pdf.IO
         /// <summary>
         /// Reads cross-reference stream(s).
         /// </summary>
-        PdfTrailer ReadXRefStream(PdfCrossReferenceTable xrefTable)
+        internal PdfTrailer ReadXRefStream(PdfCrossReferenceTable xrefTable)
         {
             // Read cross-reference stream.
             //Debug.Assert(_lexer.Symbol == Symbol.Integer);

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs
@@ -369,9 +369,20 @@ namespace PdfSharp.Pdf.IO
             // Step 3: We try to read the stream content.
             // Maybe we have to re-read it in case 'endstream' was not at the
             // right place after reading with the length value coming from /Length.
-            var bytes = _lexer.ScanStream(startPosition, streamLength);
-            var stream = new PdfDictionary.PdfStream(bytes, dict);
-            dict.Stream = stream;
+            byte[] bytes;
+            try
+            {
+                // this may throw if startPosition + streamLength > length of stream
+                bytes = _lexer.ScanStream(startPosition, streamLength);
+                var stream = new PdfDictionary.PdfStream(bytes, dict);
+                dict.Stream = stream;
+            }
+            catch
+            {
+                // reset stream position
+                _lexer.Position = startPosition;
+                // ignore exception, we'll try again after determining real stream-length
+            }
 #if DEBUG_  // Check it with Notepad++ directly in PDF file.
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
             if (bytes is not null && bytes.Length > 0)

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -300,7 +300,14 @@ namespace PdfSharp.Pdf.IO
                 var parser = new Parser(_document, options ?? new PdfReaderOptions(), _logger);
 
                 // 1. Read all trailers or cross-reference streams, but no objects.
-                _document.Trailer = parser.ReadTrailer();
+                try
+                {
+                    _document.Trailer = parser.ReadTrailer();
+                }
+                catch
+                {
+                    _document.Trailer = PdfTrailer.Rebuild(_document, stream, parser);
+                }
                 if (_document.Trailer == null!)
                     ParserDiagnostics.ThrowParserException(
                         "Invalid PDF file: no trailer found."); // TODO L10N using PsMsgs

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -899,7 +899,7 @@ namespace PdfSharp.Pdf
         /// <summary>
         /// Gets the standard security handler, if existing and encryption is active.
         /// </summary>
-        internal PdfStandardSecurityHandler? EffectiveSecurityHandler => Trailer.EffectiveSecurityHandler;
+        internal PdfStandardSecurityHandler? EffectiveSecurityHandler => Trailer?.EffectiveSecurityHandler;
 
         internal PdfTrailer Trailer { get; set; } = default!;
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfString.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfString.cs
@@ -277,9 +277,11 @@ namespace PdfSharp.Pdf
                 return true;
             }
 
-#if true // UTF-16LE is not defined as valid text string encoding in PDF reference.
+#if false // UTF-16LE is not defined as valid text string encoding in PDF reference.
             if (value is ['\xFF', '\xFE', ..])
+            {
                 throw new NotImplementedException("Found UTF-16LE string. Please send us the PDF file and we will fix it (issues (at) pdfsharp.net).");
+            }
 #else
             // Adobe Reader also supports UTF-16LE.
             if (value is ['\xFF', '\xFE', ..])


### PR DESCRIPTION
This PR is intended to allow PDFsharp to read documents that would otherwise throw exceptions when trying to open them.

Notable changes:
- Instead of throwing an "Unexpected character"-exception, the offending character is simply ignored.
 For example, in one of my test-documents there is a string-value that looks like this: `(text))` 
 Note the double closing parenthesis, which can (and should) be just ignored.
- When a dictionary with an incorrect stream-length is encountered, the library takes the (wrong) specified length, adds an arbitrary tolerance of 20 bytes and tries to find the end of the stream within that range.  
The tolerance of 20 bytes is insufficient in most (if not all) cases.  
The method was enhanced to search for the end of the stream until EOF.
- In one of my test-documents there are UTF-16LE encoded strings, which triggered a `NotImplementedException`.
 The code that throws was inside an `#if true` block but the `#else` block seems to work just fine, so i just switched the condition.
- For _really_ corrupt documents (e.g. xref-table cut off at the end, `startxref`-keyword pointing to something that is not an xref-table, etc.), an attempt is made to rebuild the trailer and the CrossReferenceTable by manually scanning the whole document.

I included a zip-file containing the documents (out of my >1000 test-files), that could not be opened with the original version 6.2.0-preview-1, but opened just fine in Chrome, Edge, Firefox and Acrobat Reader.
With the changes, PDFsharp was able to open them.

[DefectFiles.zip](https://github.com/user-attachments/files/16641524/DefectFiles.zip)

I used the following test-case (in `PdfSharp.Tests.IO.ReaderTests`):

```
[Theory]
[InlineData(@"path\to\zip-files\issue #70.PDF", 1)]
[InlineData(@"path\to\zip-files\issue #70 - Copy.PDF", 1)]
[InlineData(@"path\to\zip-files\PdfTrailer_not_null_001(PageCount).pdf", 14)]
[InlineData(@"path\to\zip-files\PdfTrailer_not_null_002(PageCount).pdf", 1)]
[InlineData(@"path\to\zip-files\PdfTrailer_not_null_003(PageCount).pdf", 100)]
[InlineData(@"path\to\zip-files\Unexpected_Token_0x0029(PageCount).pdf", 120)]
[InlineData(@"path\to\zip-files\Unexpected_Token_426(PageCount).pdf", 2)]
[InlineData(@"path\to\zip-files\Unexpected_Token_EmptyChar(PageCount).pdf", 3)]
[InlineData(@"path\to\zip-files\Unexpected_Token_endobj(PageCount).pdf", 6)]
[InlineData(@"path\to\zip-files\Unexpected_Token_SlashE(PageCount).pdf", 7)]
[InlineData(@"path\to\zip-files\Contains UTF16-LE.pdf", 74)]
public void TestSingleFile(string filePath, int expectedPageCount)
{
    File.Exists(filePath).Should().BeTrue("File should exist");
    VerifyPdfCanBeImported(filePath, expectedPageCount);
}

private static void VerifyPdfCanBeImported(string filePath, int expectedPageCount = 0)
{
    var act = () =>
    {
        var document = PdfReader.Open(filePath, PdfDocumentOpenMode.Import);
        var documentCopy = new PdfDocument();
        if (expectedPageCount > 0)
            document.Pages.Count.Should().Be(expectedPageCount);
        foreach (var page in document.Pages)
        {
            documentCopy.AddPage(page);
        }
        documentCopy.Save(Path.Combine(Path.GetTempPath(), "out.pdf"));
    };
    act.Should().NotThrow();
}
```
