### PR TITLE
Support Version 5 Revision 5 decryption

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Internal/ErrorHelpers.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Internal/ErrorHelpers.cs
@@ -72,7 +72,7 @@ namespace PdfSharp.Internal
             new("The encryption version value must be 5 for encryption version 5.");
 
         public static InvalidOperationException InvalidOperationException_InvalidRevisionValueForEncryptionVersion5() =>
-            new("The encryption revision value must be 6 for encryption version 5.");
+            new("The encryption revision value must be 5 (deprecated) or 6 for encryption version 5.");
 
         public static InvalidOperationException InvalidOperationException_InvalidLengthValueForEncryptionVersion5() =>
             new("The Length value must be omitted or 256 for encryption version 5.");


### PR DESCRIPTION
This PR adds support for Version 5 Revision 5 encryption, which is proprietary from Adobe.

> 5 (PDF 2.0; deprecated) Shall not be used. This value was used by a  deprecated proprietary Adobe extension

While it should not be used anymore in PDF2.0 compliant documents, users can still have some pdf that use this encryption option.
As the change is quite small, it is probably interesting to support it.

Note that the test uses py-pdf files as I cannot share files from my company ; I suppose appropriate files should be provided through assets files download ?