### PR TITLE
Support inline dictionaries for Encrypt tag

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -308,12 +308,17 @@ namespace PdfSharp.Pdf.IO
                 // Reference.Values available by now: All trailers and cross-reference streams (which are not encrypted by definition). 
 
                 // 2. Read the encryption dictionary, if existing.
-                if (_document.Trailer!.Elements[PdfTrailer.Keys.Encrypt] is PdfReference xrefEncrypt)
+                var encryptPdfItem = _document.Trailer!.Elements[PdfTrailer.Keys.Encrypt];
+                if (encryptPdfItem is PdfReference xrefEncrypt)
                 {
                     var encrypt = parser.ReadIndirectObject(xrefEncrypt, null, true);
                     encrypt.Reference = xrefEncrypt;
                     xrefEncrypt.Value = encrypt;
 
+                    _document.SecurityHandler.PrepareForReading();
+                }
+                else if (encryptPdfItem is PdfDictionary)
+                {
                     _document.SecurityHandler.PrepareForReading();
                 }
                 // References available by now: All references to file-level objects.

--- a/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/IO/ReaderTests.cs
+++ b/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/IO/ReaderTests.cs
@@ -298,5 +298,15 @@ namespace PdfSharp.Tests.IO
                 }
             }
         }
+   
+        [Fact]
+        public void Encrypt_can_be_an_inline_dictionary()
+        {
+            const string path = @"C:\Users\ArnaudTAMAILLON\Downloads\dictionary_encrypt.pdf";
+            var act = () => PdfReader.Open(path, PdfDocumentOpenMode.Import);
+            act.Should().NotThrow();
+            act = () => PdfReader.Open(path, "asdfzxcv", PdfDocumentOpenMode.Modify);
+            act.Should().NotThrow();
+        }
     }
 }


### PR DESCRIPTION
PDFSharp assumes that `/Encrypt` is a reference. But it can actually be an inlined dictionary.

I forged the following file to replicate a situation I was having: 
[dictionary_encrypt.pdf](https://github.com/user-attachments/files/16726930/dictionary_encrypt.pdf).
I used it for the unit test.


