### PR TITLE
Ensure all trailers security handlers are initialized at parsing time

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -308,13 +308,17 @@ namespace PdfSharp.Pdf.IO
                 // Reference.Values available by now: All trailers and cross-reference streams (which are not encrypted by definition). 
 
                 // 2. Read the encryption dictionary, if existing.
-                if (_document.Trailer!.Elements[PdfTrailer.Keys.Encrypt] is PdfReference xrefEncrypt)
+                var trailer = _document.Trailer;
+                while (trailer != null)
                 {
-                    var encrypt = parser.ReadIndirectObject(xrefEncrypt, null, true);
-                    encrypt.Reference = xrefEncrypt;
-                    xrefEncrypt.Value = encrypt;
-
-                    _document.SecurityHandler.PrepareForReading();
+                    if (_document.Trailer!.Elements[PdfTrailer.Keys.Encrypt] is PdfReference xrefEncrypt)
+                    {
+                        var encrypt = parser.ReadIndirectObject(xrefEncrypt, null, true);
+                        encrypt.Reference = xrefEncrypt;
+                        xrefEncrypt.Value = encrypt;
+                        
+                        _document.SecurityHandler.PrepareForReading();
+                    }
                 }
                 // References available by now: All references to file-level objects.
                 // Reference.Values available by now: All trailers and cross-reference streams and the encryption dictionary.


### PR DESCRIPTION
Currently, the Encrypt key is only read for the document trailer.
However, when mutliple trailers are present, the code for reading all indirect objects in [ReadAllIndirectObjects](https://github.com/empira/PDFsharp/blob/5fbf6ed14740bc4e16786816882d32e43af3ff5d/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Parser.cs#L1009) can lead to calling [IsSecurityHandler](https://github.com/empira/PDFsharp/blob/5fbf6ed14740bc4e16786816882d32e43af3ff5d/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Security/PdfStandardSecurityHandler.cs#L249) method, that can iterate over SecurityHandlers for all previous trailers.
The [lazy initialization](https://github.com/empira/PDFsharp/blob/5fbf6ed14740bc4e16786816882d32e43af3ff5d/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfTrailer.cs#L140-L141) code will access the Encrypt key under the asumption that it has been read already, leading to an exception.

Unfortunately, I cannot share the file leading to this discovery, sorry for this.