### PR TITLE
XMP metadata: correct datetime format for CreateDate and ModifyDate

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfMetadata.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfMetadata.cs
@@ -59,8 +59,11 @@ namespace PdfSharp.Pdf
             var instanceId = Guid.NewGuid().ToString();
             var documentId = Guid.NewGuid().ToString();
 
-            var creationDate = _document.Info.CreationDate.ToString("o");
-            var modificationDate = _document.Info.CreationDate.ToString("o");
+            static DateTime SpecifyLocalDateTimeKindIfUnspecified(DateTime value)
+                => value.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(value, DateTimeKind.Local) : value;
+
+            var creationDate = SpecifyLocalDateTimeKindIfUnspecified(_document.Info.CreationDate).ToString("yyyy-MM-ddTHH:mm:ssK");
+            var modificationDate = SpecifyLocalDateTimeKindIfUnspecified(_document.Info.CreationDate).ToString("yyyy-MM-ddTHH:mm:ssK");
 
             var author = _document.Info.Author;
             var creator = _document.Info.Creator;


### PR DESCRIPTION
Validation tools for PDF/A reports "sync errors" between the "CreationDate" and the "CreateDate" in the metadata.

Using the right format inside the metadata resolves this.

Fixes #166 