### PR TITLE
Make PDFSharp compatible with trimming

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp-gdi/PdfSharp-gdi.csproj
+++ b/src/foundation/src/PDFsharp/src/PdfSharp-gdi/PdfSharp-gdi.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\shared\src\PdfSharp.System\System\CompilerServices.cs" Link="root\CompilerServices.cs" />
+    <Compile Include="..\..\..\shared\src\PdfSharp.System\System\CodeAnalysis.cs" Link="root\CodeAnalysis.cs" />
     <Compile Include="..\PdfSharp\!internal\Configuration.cs" Link="!internal\Configuration.cs" />
     <Compile Include="..\PdfSharp\!internal\Directives.cs" Link="!internal\Directives.cs" />
     <Compile Include="..\PdfSharp\!internal\TargetContext.cs" Link="!internal\TargetContext.cs" />

--- a/src/foundation/src/PDFsharp/src/PdfSharp-wpf/PdfSharp-wpf.csproj
+++ b/src/foundation/src/PDFsharp/src/PdfSharp-wpf/PdfSharp-wpf.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\shared\src\PdfSharp.System\System\CodeAnalysis.cs" Link="root\CodeAnalysis.cs" />
     <Compile Include="..\..\..\shared\src\PdfSharp.System\System\CompilerServices.cs" Link="root\CompilerServices.cs" />
     <Compile Include="..\PdfSharp\!internal\Configuration.cs" Link="!internal\Configuration.cs" />
     <Compile Include="..\PdfSharp\!internal\Directives.cs" Link="!internal\Directives.cs" />

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfInternals.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfInternals.cs
@@ -1,6 +1,7 @@
 ﻿// PDFsharp - A .NET library for processing PDF
 // See the LICENSE file in the solution root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using PdfSharp.Pdf.IO;
 
@@ -160,7 +161,7 @@ namespace PdfSharp.Pdf.Advanced
         /// Creates the indirect object of the specified type, adds it to the document,
         /// and returns the object.
         /// </summary>
-        public T CreateIndirectObject<T>() where T : PdfObject
+        public T CreateIndirectObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>() where T : PdfObject
         {
 #if true
             T obj = Activator.CreateInstance<T>();

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/EntryInfoAttribute.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/EntryInfoAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// PDFsharp - A .NET library for processing PDF
 // See the LICENSE file in the solution root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace PdfSharp.Pdf
 {
     /// <summary>
@@ -64,14 +66,14 @@ namespace PdfSharp.Pdf
             KeyType = keyType;
         }
 
-        public KeyInfoAttribute(KeyType keyType, Type objectType)
+        public KeyInfoAttribute(KeyType keyType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type objectType)
         {
             //_version = version;
             KeyType = keyType;
             _objectType = objectType;
         }
 
-        public KeyInfoAttribute(string version, KeyType keyType, Type objectType)
+        public KeyInfoAttribute(string version, KeyType keyType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type objectType)
         {
             //_version = version;
             KeyType = keyType;
@@ -92,11 +94,13 @@ namespace PdfSharp.Pdf
         }
         KeyType _entryType;
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         public Type ObjectType
         {
             get => _objectType!; // ?? NRT.ThrowOnNull<Type>(); Can be null.
             set => _objectType = value;
         }
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         Type? _objectType;
 
         public string FixedValue

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/KeysBase.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/KeysBase.cs
@@ -1,6 +1,8 @@
 // PDFsharp - A .NET library for processing PDF
 // See the LICENSE file in the solution root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace PdfSharp.Pdf
 {
     /// <summary>
@@ -8,7 +10,7 @@ namespace PdfSharp.Pdf
     /// </summary>
     public class KeysBase
     {
-        internal static DictionaryMeta CreateMeta(Type type) => new(type);
+        internal static DictionaryMeta CreateMeta([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type) => new(type);
 
         /// <summary>
         /// Creates the DictionaryMeta with the specified default type to return in DictionaryElements.GetValue
@@ -17,7 +19,7 @@ namespace PdfSharp.Pdf
         /// <param name="type">The type.</param>
         /// <param name="defaultContentKeyType">Default type of the content key.</param>
         /// <param name="defaultContentType">Default type of the content.</param>
-        internal static DictionaryMeta CreateMeta(Type type, KeyType defaultContentKeyType, Type defaultContentType) 
+        internal static DictionaryMeta CreateMeta([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type, KeyType defaultContentKeyType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type defaultContentType) 
             => new(type, defaultContentKeyType, defaultContentType);
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/KeysMeta.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/KeysMeta.cs
@@ -1,6 +1,7 @@
 // PDFsharp - A .NET library for processing PDF
 // See the LICENSE file in the solution root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using PdfSharp.Pdf.Advanced;
 
@@ -38,6 +39,7 @@ namespace PdfSharp.Pdf
 
         public string FixedValue { get; }
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         public Type ObjectType { get; set; }
 
         public bool CanBeIndirect => (KeyType & KeyType.MustNotBeIndirect) == 0;
@@ -45,6 +47,7 @@ namespace PdfSharp.Pdf
         /// <summary>
         /// Returns the type of the object to be created as value for the described key.
         /// </summary>
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         public Type GetValueType()
         {
             var type = ObjectType;
@@ -134,7 +137,7 @@ namespace PdfSharp.Pdf
     /// </summary>
     class DictionaryMeta
     {
-        public DictionaryMeta(Type type)
+        public DictionaryMeta([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
         {
             var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
             foreach (var field in fields)
@@ -159,7 +162,7 @@ namespace PdfSharp.Pdf
         /// <param name="type">The type.</param>
         /// <param name="defaultContentKeyType">Default type of the content key.</param>
         /// <param name="defaultContentType">Default type of the content.</param>
-        public DictionaryMeta(Type type, KeyType defaultContentKeyType, Type defaultContentType) : this(type)
+        public DictionaryMeta([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type, KeyType defaultContentKeyType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type defaultContentType) : this(type)
         {
             _defaultContentKeyDescriptor = new KeyDescriptor(new KeyInfoAttribute(defaultContentKeyType, defaultContentType));
         }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDictionary.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDictionary.cs
@@ -863,6 +863,7 @@ namespace PdfSharp.Pdf
             /// <summary>
             /// Returns the type of the object to be created as value of the specified key.
             /// </summary>
+            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
             Type? GetValueType(string key)  // TODO: move to PdfObject
             {
                 Type? type = null;
@@ -880,7 +881,7 @@ namespace PdfSharp.Pdf
                 return type;
             }
 
-            PdfArray CreateArray(Type type, PdfArray? oldArray)
+            PdfArray CreateArray([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type, PdfArray? oldArray)
             {
 #if true
                 PdfArray? array;
@@ -942,7 +943,7 @@ namespace PdfSharp.Pdf
 #endif
             }
 
-            PdfDictionary CreateDictionary(Type type, PdfDictionary? oldDictionary)
+            PdfDictionary CreateDictionary([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type, PdfDictionary? oldDictionary)
             {
 #if true
                 ConstructorInfo? ctorInfo;
@@ -1001,7 +1002,7 @@ namespace PdfSharp.Pdf
 #endif
             }
 
-            PdfItem CreateValue(Type type, PdfDictionary? oldValue)
+            PdfItem CreateValue([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type, PdfDictionary? oldValue)
             {
 #if true
                 var ctorInfo = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,

--- a/src/foundation/src/PDFsharp/src/PdfSharp/PdfSharp.csproj
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/PdfSharp.csproj
@@ -7,6 +7,8 @@
     <DefineConstants>CORE</DefineConstants>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\..\StrongnameKey.snk</AssemblyOriginatorKeyFile>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -57,6 +59,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\shared\src\PdfSharp.System\System\CodeAnalysis.cs" Link="root\CodeAnalysis.cs" />
     <Compile Include="..\..\..\shared\src\PdfSharp.System\System\CompilerServices.cs" Link="root\CompilerServices.cs" />
   </ItemGroup>
 

--- a/src/foundation/src/shared/src/PdfSharp.Shared/PdfSharp.Shared.csproj
+++ b/src/foundation/src/shared/src/PdfSharp.Shared/PdfSharp.Shared.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>PdfSharp</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\..\StrongnameKey.snk</AssemblyOriginatorKeyFile>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/foundation/src/shared/src/PdfSharp.System/PdfSharp.System.csproj
+++ b/src/foundation/src/shared/src/PdfSharp.System/PdfSharp.System.csproj
@@ -6,6 +6,8 @@
     <!--<Error Condition="!Exists('C:\Process\Fail.txt')" Text="Process did not pass!" />-->
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\..\StrongnameKey.snk</AssemblyOriginatorKeyFile>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/foundation/src/shared/src/PdfSharp.System/System/CodeAnalysis.cs
+++ b/src/foundation/src/shared/src/PdfSharp.System/System/CodeAnalysis.cs
@@ -1,0 +1,152 @@
+using System;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NET6_0_OR_GREATER
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// When this attribute is applied to a class, interface, or struct, the members specified
+    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 0x2000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+#endif
+}

--- a/src/foundation/src/shared/src/PdfSharp.System/System/CompilerServices.cs
+++ b/src/foundation/src/shared/src/PdfSharp.System/System/CompilerServices.cs
@@ -7,6 +7,7 @@
 
 namespace System.Runtime.CompilerServices
 {
+#if !NET6_0_OR_GREATER
     /// <summary>
     /// Extension method GetSubArray required for the built-in range operator (e.g.'[1..9]').
     /// Fun fact: This class must be compiled into each assembly. If it is only visible through
@@ -45,4 +46,5 @@ namespace System.Runtime.CompilerServices
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
* Enable trimming/AOT analyzers so that trimming/AOT issues get flagged at build time (added the `IsTrimmable`/`IsAotCompatible` properties to relevant csproj files)
* Help reflection static analysis by adding `DynamicallyAccessedMembers` annotations where flagged by the analyzer.

With this:

* Apps that use PDFSharp no longer generate trimming warnings, since the reflection use can be statically analyzed and proved safe.
* Workarounds like https://github.com/empira/PDFsharp/issues/149#issuecomment-2286107223 are no longer needed.
* Apps can be much smaller. A .NET 8 app with PublishAot that just merges PDF files without doing anything else is 4,370,432 bytes with the current version of PDFSharp and the above workaround (and generates a warning). With the version in this PR it no longer generates warnings, doesn't need a workaround, and comes down to 2,733,056 bytes.