### PR TITLE
RTF: Fix of very wide images (50 cm +)

### DIFF
--- a/src/foundation/src/MigraDoc/src/MigraDoc.RtfRendering/RtfRendering/ImageRenderer.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.RtfRendering/RtfRendering/ImageRenderer.cs
@@ -175,16 +175,8 @@ namespace MigraDoc.RtfRendering
         /// </summary>
         void RenderDimensionSettings()
         {
-            var shapeWidthPt = GetShapeWidth().Point;
-            var shapeHeightPt = GetShapeHeight().Point;
-
-            var scaleX = shapeWidthPt / _originalWidth.Point;
-            var scaleY = shapeHeightPt / _originalHeight.Point;
-            _rtfWriter.WriteControl("picscalex", (int)(scaleX * 100));
-            _rtfWriter.WriteControl("picscaley", (int)(scaleY * 100));
-
-            RenderUnit("pichgoal", shapeHeightPt / scaleY);
-            RenderUnit("picwgoal", shapeWidthPt / scaleX);
+            RenderUnit("pichgoal", shapeHeightPt);
+            RenderUnit("picwgoal", shapeWidthPt);
 
             //A bit obscure, but necessary for Word 2000:
             _rtfWriter.WriteControl("pich", (int)(_originalHeight.Millimeter * 100));


### PR DESCRIPTION
If you insert a wide image (probably more than 50 cm), Word will resize width by Math.Ceil (cm / 50) times (not sure about the exact values), while Wordpad will delete it away.

The problem is that **picscale** will remain value BEFORE resize. 

This can be fixed if you take into account such a scenario, but it is not really necessary. Wide images created in Word does not use **picscale** anyway, it sets the target size in **picwgoal/pichgoal**, and such problems do not arise.

And yes, you can resize original image, but the quality when zooming in will be terrible.