### PR TITLE
Handle line feed character in EOD marker for base85 decoder

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Filters/ASCII85Decode.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Filters/ASCII85Decode.cs
@@ -135,9 +135,14 @@ namespace PdfSharp.Pdf.Filters
                 }
                 else if (ch == '~')
                 {
-                    if ((char)data[idx + 1] != '>')
-                        throw new ArgumentException("Illegal character.", nameof(data));
-                    break;
+                    if ((char)data[idx + 1] == '>') {
+                        break;
+                    }
+                    if((char)data[idx + 1] == '\n' && (char)data[idx + 2] == '>') {
+                        idx++;
+                        break;
+                    }
+                    throw new ArgumentException("Illegal character.", nameof(data));
                 }
                 // ignore unknown character
             }


### PR DESCRIPTION
Hello :)
We are receiving base64 encoded pdfs from our partner, which has an additional non-spec line feed character. We use pdfsharp to open them with a memory stream, and perform some edits.

![image](https://github.com/user-attachments/assets/05429cc8-40e6-4d41-9f87-f06456961963)

The adobe documentation outlines the EOD marker as ~>: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf

![image](https://github.com/user-attachments/assets/83d04944-45f7-42e7-b5ad-0537b8d6ae5e)

But if I open the pdf in several popular pdf viewers/browsers it correctly interprets the pdfs, contrary pdfsharp raises an invalid character exception.

Should this path be less strict, or is there something I am misunderstanding?