### PR TITLE
Compatibility options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ InternalAgentState.json
 *tempfile.*
 launchsettings.json
 testEnvironments.json
+.cr/

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Drawing.Pdf/PdfGraphicsState.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Drawing.Pdf/PdfGraphicsState.cs
@@ -42,13 +42,15 @@ namespace PdfSharp.Drawing.Pdf
         public void PushState()
         {
             // BeginGraphic
-            renderer.Append("q/n");
+            renderer.Append("q");
+            renderer.Append(renderer.Owner.Options.LineEnding);
         }
 
         public void PopState()
         {
             //BeginGraphic
-            renderer.Append("Q/n");
+            renderer.Append("Q");
+            renderer.Append(renderer.Owner.Options.LineEnding);
         }
 
         #region Stroke
@@ -64,8 +66,8 @@ namespace PdfSharp.Drawing.Pdf
 
         public void RealizePen(XPen pen, PdfColorMode colorMode)
         {
-            const string format = Config.SignificantDecimalPlaces3;
             const string format2 = Config.SignificantDecimalPlaces2;
+            const string format3 = Config.SignificantDecimalPlaces3;
 
             XColor color = pen.Color;
             bool overPrint = pen.Overprint;
@@ -73,19 +75,22 @@ namespace PdfSharp.Drawing.Pdf
 
             if (_realizedLineWith != pen.Width)
             {
-                renderer.AppendFormatArgs("{0:" + format + "} w\n", pen.Width);
+                renderer.AppendFormatArgs("{0:" + format3 + "} w", pen.Width);
+                renderer.Append(renderer.Owner.Options.LineEnding);
                 _realizedLineWith = pen.Width;
             }
 
             if (_realizedLineCap != (int)pen.LineCap)
             {
-                renderer.AppendFormatArgs("{0} J\n", (int)pen.LineCap);
+                renderer.AppendFormatArgs("{0} J", (int)pen.LineCap);
+                renderer.Append(renderer.Owner.Options.LineEnding);
                 _realizedLineCap = (int)pen.LineCap;
             }
 
             if (_realizedLineJoin != (int)pen.LineJoin)
             {
-                renderer.AppendFormatArgs("{0} j\n", (int)pen.LineJoin);
+                renderer.AppendFormatArgs("{0} j", (int)pen.LineJoin);
+                renderer.Append(renderer.Owner.Options.LineEnding);
                 _realizedLineJoin = (int)pen.LineJoin;
             }
 
@@ -93,7 +98,8 @@ namespace PdfSharp.Drawing.Pdf
             {
                 if (_realizedMiterLimit != (int)pen.MiterLimit && (int)pen.MiterLimit != 0)
                 {
-                    renderer.AppendFormatInt("{0} M\n", (int)pen.MiterLimit);
+                    renderer.AppendFormatInt("{0} M", (int)pen.MiterLimit);
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                     _realizedMiterLimit = (int)pen.MiterLimit;
                 }
             }
@@ -111,23 +117,28 @@ namespace PdfSharp.Drawing.Pdf
                 switch (dashStyle)
                 {
                     case XDashStyle.Solid:
-                        renderer.Append("[]0 d\n");
+                        renderer.Append("[]0 d");
+                        renderer.Append(renderer.Owner.Options.LineEnding);
                         break;
 
                     case XDashStyle.Dash:
-                        renderer.AppendFormatArgs("[{0:" + format2 + "} {1:" + format2 + "}]0 d\n", dash, dot);
+                        renderer.AppendFormatArgs("[{0:" + format2 + "} {1:" + format2 + "}]0 d", dash, dot);
+                        renderer.Append(renderer.Owner.Options.LineEnding);
                         break;
 
                     case XDashStyle.Dot:
-                        renderer.AppendFormatArgs("[{0:" + format2 + "}]0 d\n", dot);
+                        renderer.AppendFormatArgs("[{0:" + format2 + "}]0 d", dot);
+                        renderer.Append(renderer.Owner.Options.LineEnding);
                         break;
 
                     case XDashStyle.DashDot:
-                        renderer.AppendFormatArgs("[{0:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "}]0 d\n", dash, dot);
+                        renderer.AppendFormatArgs("[{0:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "}]0 d", dash, dot);
+                        renderer.Append(renderer.Owner.Options.LineEnding);
                         break;
 
                     case XDashStyle.DashDotDot:
-                        renderer.AppendFormatArgs("[{0:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "}]0 d\n", dash, dot);
+                        renderer.AppendFormatArgs("[{0:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "} {1:" + format2 + "}]0 d", dash, dot);
+                        renderer.Append(renderer.Owner.Options.LineEnding);
                         break;
 
                     case XDashStyle.Custom:
@@ -146,7 +157,8 @@ namespace PdfSharp.Drawing.Pdf
                                 pdf.Append(' ');
                                 pdf.Append(PdfEncoders.ToString(0.2 * pen.Width));
                             }
-                            pdf.AppendFormat(CultureInfo.InvariantCulture, "]{0:" + format + "} d\n", pen.DashOffset * pen.Width);
+                            pdf.AppendFormat(CultureInfo.InvariantCulture, "]{0:" + format3 + "} d", pen.DashOffset * pen.Width);
+                            pdf.Append(renderer.Owner.Options.LineEnding);
                             string pattern = pdf.ToString();
 
                             // IMPROVE
@@ -168,7 +180,8 @@ namespace PdfSharp.Drawing.Pdf
                 if (_realizedStrokeColor.Rgb != color.Rgb)
                 {
                     renderer.Append(PdfEncoders.ToString(color, PdfColorMode.Rgb));
-                    renderer.Append(" RG\n");
+                    renderer.Append(" RG");
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                 }
             }
             else
@@ -176,7 +189,8 @@ namespace PdfSharp.Drawing.Pdf
                 if (!ColorSpaceHelper.IsEqualCmyk(_realizedStrokeColor, color))
                 {
                     renderer.Append(PdfEncoders.ToString(color, PdfColorMode.Cmyk));
-                    renderer.Append(" K\n");
+                    renderer.Append(" K");
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                 }
             }
 
@@ -184,7 +198,8 @@ namespace PdfSharp.Drawing.Pdf
             {
                 PdfExtGState extGState = renderer.Owner.ExtGStateTable.GetExtGStateStroke(color.A, overPrint);
                 string gs = renderer.Resources.AddExtGState(extGState);
-                renderer.AppendFormatString("{0} gs\n", gs);
+                renderer.AppendFormatString("{0} gs", gs);
+                renderer.Append(renderer.Owner.Options.LineEnding);
 
                 // Must create transparency group.
                 if (renderer._page != null! && color.A < 1)
@@ -238,8 +253,10 @@ namespace PdfSharp.Drawing.Pdf
                     PdfShadingPattern pattern = new PdfShadingPattern(renderer.Owner);
                     pattern.SetupFromBrush(gradientBrush, matrix, renderer);
                     string name = renderer.Resources.AddPattern(pattern);
-                    renderer.AppendFormatString("/Pattern cs\n", name);
-                    renderer.AppendFormatString("{0} scn\n", name);
+                    renderer.AppendFormatString("/Pattern cs", name);
+                    renderer.Append(renderer.Owner.Options.LineEnding);
+                    renderer.AppendFormatString("{0} scn", name);
+                    renderer.Append(renderer.Owner.Options.LineEnding);
 
                     // Invalidate fill color.
                     _realizedFillColor = XColor.Empty;
@@ -256,7 +273,8 @@ namespace PdfSharp.Drawing.Pdf
                 if (_realizedFillColor.IsEmpty || _realizedFillColor.Rgb != color.Rgb)
                 {
                     renderer.Append(PdfEncoders.ToString(color, PdfColorMode.Rgb));
-                    renderer.Append(" rg\n");
+                    renderer.Append(" rg");
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                 }
             }
             else
@@ -266,7 +284,8 @@ namespace PdfSharp.Drawing.Pdf
                 if (_realizedFillColor.IsEmpty || !ColorSpaceHelper.IsEqualCmyk(_realizedFillColor, color))
                 {
                     renderer.Append(PdfEncoders.ToString(color, PdfColorMode.Cmyk));
-                    renderer.Append(" k\n");
+                    renderer.Append(" k");
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                 }
             }
 
@@ -275,7 +294,8 @@ namespace PdfSharp.Drawing.Pdf
 
                 PdfExtGState extGState = renderer.Owner.ExtGStateTable.GetExtGStateNonStroke(color.A, overPrint);
                 string gs = renderer.Resources.AddExtGState(extGState);
-                renderer.AppendFormatString("{0} gs\n", gs);
+                renderer.AppendFormatString("{0} gs", gs);
+                renderer.Append(renderer.Owner.Options.LineEnding);
 
                 // Must create transparency group.
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -307,7 +327,8 @@ namespace PdfSharp.Drawing.Pdf
 
         public void RealizeFont(XGlyphTypeface glyphTypeface, double emSize, XBrush brush, int renderingMode, FontType fontType)
         {
-            const string format = Config.SignificantDecimalPlaces3;
+            const string format3 = Config.SignificantDecimalPlaces3;
+            const string format = "{0} {1:" + format3 + "} Tf";
 
             // So far rendering mode 0 (fill text) and 2 (fill, then stroke text) only.
             RealizeBrush(brush, renderer._colorMode, renderingMode, emSize); // _renderer.page.document.Options.ColorMode);
@@ -315,7 +336,8 @@ namespace PdfSharp.Drawing.Pdf
             // Realize rendering mode.
             if (_realizedRenderingMode != renderingMode)
             {
-                renderer.AppendFormatInt("{0} Tr\n", renderingMode);
+                renderer.AppendFormatInt("{0} Tr", renderingMode);
+                renderer.Append(renderer.Owner.Options.LineEnding);
                 _realizedRenderingMode = renderingMode;
             }
 
@@ -324,7 +346,8 @@ namespace PdfSharp.Drawing.Pdf
             {
                 if (_realizedCharSpace != 0)
                 {
-                    renderer.Append("0 Tc\n");
+                    renderer.Append("0 Tc");
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                     _realizedCharSpace = 0;
                 }
             }
@@ -333,7 +356,8 @@ namespace PdfSharp.Drawing.Pdf
                 double charSpace = emSize * Const.BoldEmphasis;
                 if (_realizedCharSpace != charSpace)
                 {
-                    renderer.AppendFormatDouble("{0:" + format + "} Tc\n", charSpace);
+                    renderer.AppendFormatDouble("{0:" + format3 + "} Tc", charSpace);
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                     _realizedCharSpace = charSpace;
                 }
             }
@@ -342,26 +366,24 @@ namespace PdfSharp.Drawing.Pdf
             string fontName = renderer.GetFontName(glyphTypeface, fontType, out _realizedFont);
             if (fontName != _realizedFontName || _realizedFontSize != emSize)
             {
-                s_formatTf ??= "{0} {1:" + format + "} Tf\n";
                 if (renderer.Gfx.PageDirection == XPageDirection.Downwards)
                 {
                     // earlier:
                     // renderer.AppendFormatFont("{0} {1:" + format + "} Tf\n", fontName, emSize);
-                    renderer.AppendFormatFont(s_formatTf, fontName, emSize);
+                    renderer.AppendFormatFont(format, fontName, emSize);
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                 }
                 else
                 {
                     // earlier:
                     // renderer.AppendFormatFont("{0} {1:" + format + "} Tf\n", fontName, emSize);
-                    renderer.AppendFormatFont(s_formatTf, fontName, emSize);
+                    renderer.AppendFormatFont(format, fontName, emSize);
+                    renderer.Append(renderer.Owner.Options.LineEnding);
                 }
                 _realizedFontName = fontName;
                 _realizedFontSize = emSize;
             }
         }
-        // ReSharper disable InconsistentNaming
-        static string? s_formatTf;
-        // ReSharper restore InconsistentNaming
 
         public XPoint RealizedTextPosition;
 
@@ -445,21 +467,22 @@ namespace PdfSharp.Drawing.Pdf
         /// </summary>
         public void RealizeCtm()
         {
+            const string format7 = Config.SignificantDecimalPlaces7;
+            const string format = "{0:" + format7 + "} {1:" + format7 + "} {2:" + format7 + "} {3:" + format7 + "} {4:"
+                                    + format7 + "} {5:" + format7 + "} cm";
+
             //if (MustRealizeCtm)
             if (!UnrealizedCtm.IsIdentity)
             {
                 Debug.Assert(!UnrealizedCtm.IsIdentity, "mrCtm is unnecessarily set.");
-
-                const string format = Config.SignificantDecimalPlaces7;
-                s_formatCtm ??= "{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:"
-                                + format + "} {5:" + format + "} cm\n";
 
                 double[] matrix = UnrealizedCtm.GetElements();
                 // Use up to six decimal digits to prevent round up problems.
                 // earlier:
                 // renderer.AppendFormatArgs("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} cm\n",
                 //     matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]);
-                renderer.AppendFormatArgs(s_formatCtm, matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]);
+                renderer.AppendFormatArgs(format, matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]);
+                renderer.Append(renderer.Owner.Options.LineEnding);
 
                 RealizedCtm.Prepend(UnrealizedCtm);
                 UnrealizedCtm = new XMatrix();
@@ -468,9 +491,6 @@ namespace PdfSharp.Drawing.Pdf
                 InverseEffectiveCtm.Invert();
             }
         }
-        // ReSharper disable InconsistentNaming
-        static string? s_formatCtm;
-        // ReSharper restore InconsistentNaming
         #endregion
 
         #region Clip Path
@@ -519,7 +539,8 @@ namespace PdfSharp.Drawing.Pdf
             else
                 renderer.AppendPath(clipPath._pathGeometry);
 #endif
-            renderer.Append(clipPath.FillMode == XFillMode.Winding ? "W n\n" : "W* n\n");
+            renderer.Append(clipPath.FillMode == XFillMode.Winding ? "W n" : "W* n");
+            renderer.Append(renderer.Owner.Options.LineEnding);
         }
 
         #endregion

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -131,10 +131,15 @@ namespace PdfSharp.Drawing.Pdf
             Realize(pen);
 
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[0].X, points[0].Y);
+            _content.Append(Owner.Options.LineEnding);
             for (int idx = 1; idx < count; idx++)
-                AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
-            _content.Append("S\n");
+            {
+                AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", points[idx].X, points[idx].Y); 
+                _content.Append(Owner.Options.LineEnding);
+            }
+            _content.Append("S"); 
+            _content.Append(Owner.Options.LineEnding);
         }
 
         // ----- DrawBezier ---------------------------------------------------------------------------
@@ -167,12 +172,16 @@ namespace PdfSharp.Drawing.Pdf
             Realize(pen);
 
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[0].X, points[0].Y); 
+            _content.Append(Owner.Options.LineEnding);
             for (int idx = 1; idx < count; idx += 3)
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            {
+                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                     points[idx].X, points[idx].Y,
                     points[idx + 1].X, points[idx + 1].Y,
                     points[idx + 2].X, points[idx + 2].Y);
+                _content.Append(Owner.Options.LineEnding);
+            }
 
             AppendStrokeFill(pen, null, XFillMode.Alternate, false);
         }
@@ -202,7 +211,8 @@ namespace PdfSharp.Drawing.Pdf
             Realize(pen);
 
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[0].X, points[0].Y); 
+            _content.Append(Owner.Options.LineEnding);
             if (count == 2)
             {
                 // Just draws a line.
@@ -252,14 +262,16 @@ namespace PdfSharp.Drawing.Pdf
 
             Realize(pen, brush);
             //AppendFormat123("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} re\n", x, y, width, -height);
-            AppendFormatRect("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} re\n", x, y + height, width, height);
+            AppendFormatRect("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} re", x, y + height, width, height); 
+            _content.Append(Owner.Options.LineEnding);
 
             if (pen != null && brush != null)
-                _content.Append("B\n");
+                _content.Append("B");
             else if (pen != null)
-                _content.Append("S\n");
+                _content.Append("S");
             else
-                _content.Append("f\n");
+                _content.Append("f"); 
+            _content.Append(Owner.Options.LineEnding);
         }
 
         // ----- DrawRectangles -----------------------------------------------------------------------
@@ -310,15 +322,20 @@ namespace PdfSharp.Drawing.Pdf
 
             // Approximate an ellipse by drawing four cubic splines.
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", x0 + δx, y0);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", x0 + δx, y0); 
+            _content.Append(Owner.Options.LineEnding);
+            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
               x0 + δx, y0 + fy, x0 + fx, y0 + δy, x0, y0 + δy);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            _content.Append(Owner.Options.LineEnding);
+            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
               x0 - fx, y0 + δy, x0 - δx, y0 + fy, x0 - δx, y0);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            _content.Append(Owner.Options.LineEnding);
+            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
               x0 - δx, y0 - fy, x0 - fx, y0 - δy, x0, y0 - δy);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            _content.Append(Owner.Options.LineEnding);
+            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
               x0 + fx, y0 - δy, x0 + δx, y0 - fy, x0 + δx, y0);
+            _content.Append(Owner.Options.LineEnding);
             AppendStrokeFill(pen, brush, XFillMode.Winding, true);
         }
 
@@ -337,9 +354,13 @@ namespace PdfSharp.Drawing.Pdf
                 throw new ArgumentException(PsMsgs.PointArrayAtLeast(2), nameof(points));
 
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[0].X, points[0].Y); 
+            _content.Append(Owner.Options.LineEnding);
             for (int idx = 1; idx < count; idx++)
-                AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+            {
+                AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", points[idx].X, points[idx].Y); 
+                _content.Append(Owner.Options.LineEnding);
+            }
 
             AppendStrokeFill(pen, brush, fillmode, true);
         }
@@ -356,7 +377,8 @@ namespace PdfSharp.Drawing.Pdf
             Realize(pen, brush);
 
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", x + width / 2, y + height / 2);
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", x + width / 2, y + height / 2); 
+            _content.Append(Owner.Options.LineEnding);
             AppendPartialArc(x, y, width, height, startAngle, sweepAngle, PathStart.LineTo1st, new XMatrix());
             AppendStrokeFill(pen, brush, XFillMode.Alternate, true);
         }
@@ -381,7 +403,8 @@ namespace PdfSharp.Drawing.Pdf
             Realize(pen, brush);
 
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[0].X, points[0].Y);
+            _content.Append(Owner.Options.LineEnding);
             if (count == 2)
             {
                 // Just draw a line.
@@ -687,12 +710,14 @@ namespace PdfSharp.Drawing.Pdf
                             var pos = new XPoint(x, y);
                             pos = WorldToView(pos);
                             AdjustTdOffset(ref pos, 0, false);
-                            AppendFormatArgs("{0:" + format2 + "} {1:" + format2 + "} Td {2} Tj\n", pos.X, pos.Y, text);
+                            AppendFormatArgs("{0:" + format2 + "} {1:" + format2 + "} Td {2} Tj", pos.X, pos.Y, text); 
+                            _content.Append(Owner.Options.LineEnding);
                         }
                         else
                         {
                             // Rest of the layers are rendered on top of the first layer.
-                            AppendFormatArgs("0 0 Td {0} Tj\n", text);
+                            AppendFormatArgs("0 0 Td {0} Tj", text); 
+                            _content.Append(Owner.Options.LineEnding);
                         }
                     }
                     x += chunkWidth;
@@ -744,7 +769,7 @@ namespace PdfSharp.Drawing.Pdf
             }
 
             // Select the number of decimal places used for the relative text positioning.
-            const string formatTj = Config.SignificantDecimalPlaces4;
+            const string format4 = Config.SignificantDecimalPlaces4;
 #if ITALIC_SIMULATION
             if (italicSimulation)
             {
@@ -752,25 +777,32 @@ namespace PdfSharp.Drawing.Pdf
                 {   // Case: Simulate Italic and simulation is already on.
 
                     // Build format string only once.
-                    s_format1 ??= "{0:" + formatTj + "} {1:" + formatTj + "} Td\n{2} Tj\n";
+                    const string s_format1 = "{0:" + format4 + "} {1:" + format4 + "} Td";
+                    const string s_format2 = "{0} Tj";
 
                     AdjustTdOffset(ref pos, verticalOffset, true);
                     // earlier:
                     //AppendFormatArgs("{0:" + format2 + "} {1:" + format2 + "} Td\n{2} Tj\n", pos.X, pos.Y, text);
-                    AppendFormatArgs(s_format1, pos.X, pos.Y, text);
+                    AppendFormatArgs(s_format1, pos.X, pos.Y);
+                    _content.Append(Owner.Options.LineEnding);
+                    AppendFormatArgs(s_format2, text);
+                    _content.Append(Owner.Options.LineEnding);
                 }
                 else
                 {   // Case: Simulate Italic and turn simulation on.
 
-                    s_format2 ??= "{0:" + formatTj + "} {1:" + formatTj + "} {2:" + formatTj + "} {3:" + formatTj + "} {4:"
-                                  + formatTj + "} {5:" + formatTj + "} Tm\n{6} Tj\n";
+                    const string s_format1 = "{0:" + format4 + "} {1:" + format4 + "} {2:" + format4 + "} {3:" + format4 + "} {4:" + format4 + "} {5:" + format4 + "} Tm";
+                    const string s_format2 = "{0} Tj";
 
                     // Italic simulation is done by skewing characters 20° to the right.
                     var m = new XMatrix(1, 0, Const.ItalicSkewAngleSinus, 1, pos.X, pos.Y);
                     // earlier:
                     //AppendFormatArgs("{0:" + format2 + "} {1:" + format2 + "} {2:" + format2 + "} {3:" + format2 + "} {4:" + format2 + "} {5:" + format2 + "} Tm\n{6} Tj\n",
                     //    m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY, text);
-                    AppendFormatArgs(s_format2, m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY, text);
+                    AppendFormatArgs(s_format1, m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY);
+                    _content.Append(Owner.Options.LineEnding);
+                    AppendFormatArgs(s_format2, text);
+                    _content.Append(Owner.Options.LineEnding);
                     _gfxState.ItalicSimulationOn = true;
                     AdjustTdOffset(ref pos, verticalOffset, false);
                 }
@@ -781,14 +813,17 @@ namespace PdfSharp.Drawing.Pdf
                 {   // Case: Do not simulate Italic but simulation is currently on.
 
                     // Same as format2, but keep code clear.
-                    s_format3 ??= "{0:" + formatTj + "} {1:" + formatTj + "} {2:" + formatTj + "} {3:" + formatTj + "} {4:"
-                                  + formatTj + "} {5:" + formatTj + "} Tm\n{6} Tj\n";
+                    const string s_format1 = "{0:" + format4 + "} {1:" + format4 + "} {2:" + format4 + "} {3:" + format4 + "} {4:" + format4 + "} {5:" + format4 + "} Tm";
+                    const string s_format2 = "{0} Tj";
 
                     var m = new XMatrix(1, 0, 0, 1, pos.X, pos.Y);
                     // earlier:
                     //AppendFormatArgs("{0:" + format2 + "} {1:" + format2 + "} {2:" + format2 + "} {3:" + format2 + "} {4:" + format2 + "} {5:" + format2 + "} Tm\n{6} Tj\n",
                     //    m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY, text);
-                    AppendFormatArgs(s_format3, m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY, text);
+                    AppendFormatArgs(s_format1, m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY);
+                    _content.Append(Owner.Options.LineEnding);
+                    AppendFormatArgs(s_format2, text);
+                    _content.Append(Owner.Options.LineEnding);
                     _gfxState.ItalicSimulationOn = false;
                     AdjustTdOffset(ref pos, verticalOffset, false);
                 }
@@ -796,17 +831,22 @@ namespace PdfSharp.Drawing.Pdf
                 {   // Case: Do not simulate Italic and simulation is already off.
 
                     // Same as format1, but keep code clear.
-                    s_format4 ??= "{0:" + formatTj + "} {1:" + formatTj + "} Td\n{2} Tj\n";
+                    const string s_format1 = "{0:" + format4 + "} {1:" + format4 + "} Td";
+                    const string s_format2 = "{0} Tj";
 
                     AdjustTdOffset(ref pos, verticalOffset, false);
                     // earlier:
                     //AppendFormatArgs("{0:" + format2 + "} {1:" + format2 + "} Td {2} Tj\n", pos.X, pos.Y, text);
-                    AppendFormatArgs(s_format4, pos.X, pos.Y, text);
+                    AppendFormatArgs(s_format1, pos.X, pos.Y);
+                    _content.Append(Owner.Options.LineEnding);
+                    AppendFormatArgs(s_format2, text);
+                    _content.Append(Owner.Options.LineEnding);
                 }
             }
 #else
                 AdjustTextMatrix(ref pos);
-                AppendFormat2("{0:" + format2 + "} {1:" + format2 + "} Td {2} Tj\n", pos.X, pos.Y, text);
+                AppendFormat2("{0:" + format2 + "} {1:" + format2 + "} Td {2} Tj", pos.X, pos.Y, text);
+                _content.Append(Owner.Options.LineEnding);
 #endif
             if (underline)
             {
@@ -830,13 +870,6 @@ namespace PdfSharp.Drawing.Pdf
                 DrawRectangle(null, brush, x, strikeoutRectY, width, strikeoutSize);
             }
         }
-
-        // ReSharper disable InconsistentNaming
-        static string? s_format1;
-        static string? s_format2;
-        static string? s_format3;
-        static string? s_format4;
-        // ReSharper restore InconsistentNaming
 
         public void DrawString(string s, XGlyphTypeface typeface, XBrush brush, XRect rect, XStringFormat format)
         {
@@ -890,13 +923,13 @@ namespace PdfSharp.Drawing.Pdf
             {
                 if (_gfx.PageDirection == XPageDirection.Downwards)
                 {
-                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q\n",
-                        x, y + height, width, height, name);
+                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", x, y + height, width, height, name);
+                    _content.Append(Owner.Options.LineEnding);
                 }
                 else
                 {
-                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q\n",
-                        x, y, width, height, name);
+                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", x, y, width, height, name);
+                    _content.Append(Owner.Options.LineEnding);
                 }
             }
             else
@@ -915,7 +948,7 @@ namespace PdfSharp.Drawing.Pdf
                     var xForm = form as XPdfForm;
                     // Reset colors in this graphics state. Usually PDF images should set them.
                     // But in rare cases they aren’t which may result in changed colors inside the image.
-                    var resetColor = xForm != null ? "\n0 g\n0 G\n" : " ";
+                    var resetColor = xForm != null ? $" 0 g 0 G " : " ";
 
                     if (_gfx.PageDirection == XPageDirection.Downwards)
                     {
@@ -928,14 +961,14 @@ namespace PdfSharp.Drawing.Pdf
                             xDraw -= xForm.Page!.MediaBox.X1;
                             yDraw += xForm.Page.MediaBox.Y1;
                         }
-                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm 100 Tz {4} Do Q\n",
-                            xDraw, yDraw + height, cx, cy, name);
+                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm 100 Tz {4} Do Q", xDraw, yDraw + height, cx, cy, name);
+                        _content.Append(Owner.Options.LineEnding);
                     }
                     else
                     {
                         // TODO_OLD Translation for MediaBox.
-                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q\n",
-                            x, y, cx, cy, name);
+                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", x, y, cx, cy, name);
+                        _content.Append(Owner.Options.LineEnding);
                     }
                 }
             }
@@ -960,13 +993,13 @@ namespace PdfSharp.Drawing.Pdf
             {
                 if (_gfx.PageDirection == XPageDirection.Downwards)
                 {
-                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do\nQ\n",
-                        x, y + height, width, height, name);
+                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", x, y + height, width, height, name);
+                    _content.Append(Owner.Options.LineEnding);
                 }
                 else
                 {
-                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q\n",
-                        x, y, width, height, name);
+                    AppendFormatImage("q {2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", x, y, width, height, name);
+                    _content.Append(Owner.Options.LineEnding);
                 }
             }
             else
@@ -984,7 +1017,7 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     var xForm = form as XPdfForm;
                     // Reset colors in this graphics state. Usually PDF images should set them, but in rare cases they don’t and this may result in changed colors inside the image.
-                    var resetColor = xForm != null ? "\n0 g\n0 G\n" : " ";
+                    var resetColor = xForm != null ? " 0 g 0 G " : " ";
 
                     if (_gfx.PageDirection == XPageDirection.Downwards)
                     {
@@ -996,14 +1029,14 @@ namespace PdfSharp.Drawing.Pdf
                             xDraw -= xForm.Page!.MediaBox.X1;
                             yDraw += xForm.Page.MediaBox.Y1;
                         }
-                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q\n",
-                            xDraw, yDraw + height, cx, cy, name);
+                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", xDraw, yDraw + height, cx, cy, name);
+                        _content.Append(Owner.Options.LineEnding);
                     }
                     else
                     {
                         // TODO_OLD Translation for MediaBox.
-                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q\n",
-                            x, y, cx, cy, name);
+                        AppendFormatImage("q" + resetColor + "{2:" + format + "} 0 0 {3:" + format + "} {0:" + format + "} {1:" + format + "} cm {4} Do Q", x, y, cx, cy, name);
+                        _content.Append(Owner.Options.LineEnding);
                     }
                 }
             }
@@ -1165,9 +1198,10 @@ namespace PdfSharp.Drawing.Pdf
         /// </summary>
         public void WriteComment(string comment)
         {
-            comment = comment.Replace("\n", "\n% ");
+            comment = comment.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", Owner.Options.LineEnding + "% ");
             // Nothing right of '% ' can break a PDF file.
-            Append("% " + comment + "\n");
+            Append(Invariant($"% {comment}"));
+            Append(Owner.Options.LineEnding);
         }
 
         #endregion
@@ -1344,12 +1378,14 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     case PathStart.MoveTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 + δx * cosα, y0 + δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", pt1.X, pt1.Y);
+                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", pt1.X, pt1.Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathStart.LineTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 + δx * cosα, y0 + δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", pt1.X, pt1.Y);
+                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", pt1.X, pt1.Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathStart.Ignore1st:
@@ -1358,8 +1394,9 @@ namespace PdfSharp.Drawing.Pdf
                 pt1 = matrix.Transform(new XPoint(x0 + δx * (cosα - κ * sinα), y0 + δy * (sinα + κ * cosα)));
                 pt2 = matrix.Transform(new XPoint(x0 + δx * (cosβ + κ * sinβ), y0 + δy * (sinβ - κ * cosβ)));
                 pt3 = matrix.Transform(new XPoint(x0 + δx * cosβ, y0 + δy * sinβ));
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                   pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y);
+                _content.Append(Owner.Options.LineEnding);
             }
             else
             {
@@ -1368,12 +1405,14 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     case PathStart.MoveTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 - δx * cosα, y0 - δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", pt1.X, pt1.Y);
+                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", pt1.X, pt1.Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathStart.LineTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 - δx * cosα, y0 - δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", pt1.X, pt1.Y);
+                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", pt1.X, pt1.Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathStart.Ignore1st:
@@ -1382,8 +1421,9 @@ namespace PdfSharp.Drawing.Pdf
                 pt1 = matrix.Transform(new XPoint(x0 - δx * (cosα - κ * sinα), y0 - δy * (sinα + κ * cosα)));
                 pt2 = matrix.Transform(new XPoint(x0 - δx * (cosβ + κ * sinβ), y0 - δy * (sinβ - κ * cosβ)));
                 pt3 = matrix.Transform(new XPoint(x0 - δx * cosβ, y0 - δy * sinβ));
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                     pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y);
+                _content.Append(Owner.Options.LineEnding);
             }
         }
 
@@ -1403,12 +1443,19 @@ namespace PdfSharp.Drawing.Pdf
             int count = points.Count;
             int start = count % 3 == 1 ? 1 : 0;
             if (start == 1)
-                AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            {
+                AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[0].X, points[0].Y);
+                _content.Append(Owner.Options.LineEnding);
+            }
+
             for (int idx = start; idx < count; idx += 3)
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            {
+                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                   points[idx].X, points[idx].Y,
                   points[idx + 1].X, points[idx + 1].Y,
                   points[idx + 2].X, points[idx + 2].Y);
+                _content.Append(Owner.Options.LineEnding);
+            }
         }
 #endif
 
@@ -1418,10 +1465,11 @@ namespace PdfSharp.Drawing.Pdf
         void AppendCurveSegment(XPoint pt0, XPoint pt1, XPoint pt2, XPoint pt3, double tension3)
         {
             const string format = Config.SignificantDecimalPlaces4;
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                 pt1.X + tension3 * (pt2.X - pt0.X), pt1.Y + tension3 * (pt2.Y - pt0.Y),
                 pt2.X - tension3 * (pt3.X - pt1.X), pt2.Y - tension3 * (pt3.Y - pt1.Y),
                 pt2.X, pt2.Y);
+            _content.Append(Owner.Options.LineEnding);
         }
 
 #if _CORE_
@@ -1452,14 +1500,19 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     case PathPointTypeStart:
                         //PDF_moveto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormat("{0:" + format + "} {1:" + format + "} m\n", points[idx].X, points[idx].Y);
+                        AppendFormat("{0:" + format + "} {1:" + format + "} m", points[idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathPointTypeLine:
                         //PDF_lineto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormat("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+                        AppendFormat("{0:" + format + "} {1:" + format + "} l", points[idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         if ((type & PathPointTypeCloseSubpath) != 0)
-                            Append("h\n");
+                        {
+                            Append("h");
+                            _content.Append(Owner.Options.LineEnding);
+                        }
                         break;
 
                     case PathPointTypeBezier:
@@ -1467,10 +1520,15 @@ namespace PdfSharp.Drawing.Pdf
                         //PDF_curveto(pdf, points[idx].X, points[idx].Y, 
                         //                 points[idx + 1].X, points[idx + 1].Y, 
                         //                 points[idx + 2].X, points[idx + 2].Y);
-                        AppendFormat("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n", points[idx].X, points[idx].Y,
+                        AppendFormat("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c", points[idx].X, points[idx].Y,
                             points[++idx].X, points[idx].Y, points[++idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         if ((types[idx] & PathPointTypeCloseSubpath) != 0)
-                            Append("h\n");
+                        {
+                            Append("h");
+                            _content.Append(Owner.Options.LineEnding);
+                        }
+
                         break;
                 }
             }
@@ -1566,14 +1624,19 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     case PathPointTypeStart:
                         //PDF_moveto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormat("{0:" + format + "} {1:" + format + "} m\n", points[idx].X, points[idx].Y);
+                        AppendFormat("{0:" + format + "} {1:" + format + "} m", points[idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathPointTypeLine:
                         //PDF_lineto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormat("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+                        AppendFormat("{0:" + format + "} {1:" + format + "} l", points[idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         if ((type & PathPointTypeCloseSubpath) != 0)
-                            Append("h\n");
+                        {
+                            Append("h"); 
+                            _content.Append(Owner.Options.LineEnding);
+                        }
                         break;
 
                     case PathPointTypeBezier:
@@ -1581,10 +1644,14 @@ namespace PdfSharp.Drawing.Pdf
                         //PDF_curveto(pdf, points[idx].X, points[idx].Y, 
                         //                 points[idx + 1].X, points[idx + 1].Y, 
                         //                 points[idx + 2].X, points[idx + 2].Y);
-                        AppendFormat("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n", points[idx].X, points[idx].Y,
+                        AppendFormat("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c", points[idx].X, points[idx].Y,
                             points[++idx].X, points[idx].Y, points[++idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         if ((types[idx] & PathPointTypeCloseSubpath) != 0)
-                            Append("h\n");
+                        {
+                            Append("h");
+                            _content.Append(Owner.Options.LineEnding);
+                        }
                         break;
                 }
             }
@@ -1618,14 +1685,19 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     case PathPointTypeStart:
                         //PDF_moveto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[idx].X, points[idx].Y);
+                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", points[idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         break;
 
                     case PathPointTypeLine:
                         //PDF_lineto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", points[idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         if ((type & PathPointTypeCloseSubpath) != 0)
-                            Append("h\n");
+                        {
+                            Append("h");
+                            _content.Append(Owner.Options.LineEnding);
+                        }
                         break;
 
                     case PathPointTypeBezier:
@@ -1633,10 +1705,14 @@ namespace PdfSharp.Drawing.Pdf
                         //PDF_curveto(pdf, points[idx].X, points[idx].Y, 
                         //                 points[idx + 1].X, points[idx + 1].Y, 
                         //                 points[idx + 2].X, points[idx + 2].Y);
-                        AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n", points[idx].X, points[idx].Y,
+                        AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c", points[idx].X, points[idx].Y,
                             points[++idx].X, points[idx].Y, points[++idx].X, points[idx].Y);
+                        _content.Append(Owner.Options.LineEnding);
                         if ((types[idx] & PathPointTypeCloseSubpath) != 0)
-                            Append("h\n");
+                        {
+                            Append("h");
+                            _content.Append(Owner.Options.LineEnding);
+                        }
                         break;
                 }
             }
@@ -1673,7 +1749,8 @@ namespace PdfSharp.Drawing.Pdf
                 {
                     // Move to start point.
                     var currentPoint = figure.StartPoint;
-                    AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", currentPoint.X, currentPoint.Y);
+                    AppendFormatPoint("{0:" + format + "} {1:" + format + "} m", currentPoint.X, currentPoint.Y);
+                    _content.Append(Owner.Options.LineEnding);
 
                     foreach (PathSegment segment in figure.Segments)
                     {
@@ -1683,7 +1760,8 @@ namespace PdfSharp.Drawing.Pdf
                                 {
                                     // Draw a single line.
                                     var point = lineSegment.Point;
-                                    AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", point.X, point.Y);
+                                    AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", point.X, point.Y);
+                                    _content.Append(Owner.Options.LineEnding);
                                     currentPoint = point;
                                 }
                                 break;
@@ -1694,7 +1772,8 @@ namespace PdfSharp.Drawing.Pdf
                                     var points = polyLineSegment.Points;
                                     foreach (SysPoint point in points)
                                     {
-                                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", point.X, point.Y);
+                                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l", point.X, point.Y);
+                                        _content.Append(Owner.Options.LineEnding);
                                     }
                                     currentPoint = points[^1];
                                 }
@@ -1706,8 +1785,9 @@ namespace PdfSharp.Drawing.Pdf
                                     var point1 = bezierSegment.Point1;
                                     var point2 = bezierSegment.Point2;
                                     var point3 = bezierSegment.Point3;
-                                    AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                                    AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                                         point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y);
+                                    _content.Append(Owner.Options.LineEnding);
                                     currentPoint = point3;
                                 }
                                 break;
@@ -1725,8 +1805,9 @@ namespace PdfSharp.Drawing.Pdf
                                             var point1 = points[idx];
                                             var point2 = points[idx + 1];
                                             var point3 = points[idx + 2];
-                                            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                                            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                                                 point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y);
+                                            _content.Append(Owner.Options.LineEnding);
                                         }
                                         currentPoint = points[count - 1];
                                     }
@@ -1771,8 +1852,9 @@ namespace PdfSharp.Drawing.Pdf
                                     var point1 = quadraticBezierSegment.Point1;
                                     var point2 = quadraticBezierSegment.Point2;
                                     var controlPoints = QuadraticToCubic(currentPoint.X, currentPoint.Y, point1.X, point1.Y, point2.X, point2.Y);
-                                    AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                                    AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                                         controlPoints.C1X, controlPoints.C1Y, controlPoints.C2X, controlPoints.C2Y, point2.X, point2.Y);
+                                    _content.Append(Owner.Options.LineEnding);
                                     currentPoint = point2;
                                 }
                                 break;
@@ -1792,8 +1874,9 @@ namespace PdfSharp.Drawing.Pdf
                                             var point2 = points[idx + 1];
                                             var controlPoints = QuadraticToCubic(currentPoint.X, currentPoint.Y, point1.X, point1.Y, point2.X, point2.Y);
 
-                                            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                                            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c",
                                                 controlPoints.C1X, controlPoints.C1Y, controlPoints.C2X, controlPoints.C2Y, point2.X, point2.Y);
+                                            _content.Append(Owner.Options.LineEnding);
                                             currentPoint = point2;
                                         }
                                     }
@@ -1811,7 +1894,10 @@ namespace PdfSharp.Drawing.Pdf
                         }
                     }
                     if (figure.IsClosed)
-                        Append("h\n");
+                    {
+                        Append("h");
+                        _content.Append(Owner.Options.LineEnding);
+                    }
                 }
             }
         }
@@ -1820,6 +1906,36 @@ namespace PdfSharp.Drawing.Pdf
         internal void Append(string value)
         {
             _content.Append(value);
+        }
+
+        internal void AppendFormatArgs(string format, object arg1)
+        {
+            _content.AppendFormat(CultureInfo.InvariantCulture, format, arg1);
+#if DEBUG_
+            string dummy = _content.ToString();
+            dummy = dummy.Substring(Math.Max(0, dummy.Length - 100));
+            dummy.GetType();
+#endif
+        }
+
+        internal void AppendFormatArgs(string format, object arg1, object arg2)
+        {
+            _content.AppendFormat(CultureInfo.InvariantCulture, format, arg1, arg2);
+#if DEBUG_
+            string dummy = _content.ToString();
+            dummy = dummy.Substring(Math.Max(0, dummy.Length - 100));
+            dummy.GetType();
+#endif
+        }
+
+        internal void AppendFormatArgs(string format, object arg1, object arg2, object arg3)
+        {
+            _content.AppendFormat(CultureInfo.InvariantCulture, format, arg1, arg2, arg3);
+#if DEBUG_
+            string dummy = _content.ToString();
+            dummy = dummy.Substring(Math.Max(0, dummy.Length - 100));
+            dummy.GetType();
+#endif
         }
 
         internal void AppendFormatArgs(string format, params object[] args)
@@ -1898,20 +2014,22 @@ namespace PdfSharp.Drawing.Pdf
             if (fillMode == XFillMode.Winding)
             {
                 if (pen != null && brush != null)
-                    _content.Append("B\n");
+                    _content.Append("B");
                 else if (pen != null)
-                    _content.Append("S\n");
+                    _content.Append("S");
                 else
-                    _content.Append("f\n");
+                    _content.Append("f");
+                _content.Append(Owner.Options.LineEnding);
             }
             else
             {
                 if (pen != null && brush != null)
-                    _content.Append("B*\n");
+                    _content.Append("B*");
                 else if (pen != null)
-                    _content.Append("S\n");
+                    _content.Append("S");
                 else
-                    _content.Append("f*\n");
+                    _content.Append("f*");
+                _content.Append(Owner.Options.LineEnding);
             }
         }
         #endregion
@@ -2050,7 +2168,8 @@ namespace PdfSharp.Drawing.Pdf
         {
             if (_streamMode == StreamMode.Text)
             {
-                _content.Append("ET\n");
+                _content.Append("ET");
+                _content.Append(Owner.Options.LineEnding);
                 _streamMode = StreamMode.Graphic;
             }
 
@@ -2079,7 +2198,10 @@ namespace PdfSharp.Drawing.Pdf
 
             // Why the check?
             if (_streamMode == StreamMode.Text)
-                _content.Append("ET\n");
+            {
+                _content.Append("ET");
+                _content.Append(Owner.Options.LineEnding);
+            }
 
             _streamMode = StreamMode.Graphic;
         }
@@ -2095,7 +2217,8 @@ namespace PdfSharp.Drawing.Pdf
             Debug.Assert(_streamMode == StreamMode.Graphic, "Undefined stream mode. Check what happened.");
 
             _streamMode = StreamMode.Text;
-            _content.Append("BT\n");
+            _content.Append("BT");
+            _content.Append(Owner.Options.LineEnding);
             // Text matrix is empty after BT.
             _gfxState.RealizedTextPosition = new XPoint();
             _gfxState.ItalicSimulationOn = false;
@@ -2380,7 +2503,8 @@ namespace PdfSharp.Drawing.Pdf
             _gfxStateStack.Push(_gfxState);
             _gfxState = _gfxState.Clone();
             _gfxState.Level = _gfxStateStack.Count;
-            Append("q\n");
+            Append("q");
+            _content.Append(Owner.Options.LineEnding);
         }
 
         /// <summary>
@@ -2391,7 +2515,8 @@ namespace PdfSharp.Drawing.Pdf
             Debug.Assert(_streamMode == StreamMode.Graphic, "Cannot restore state in text mode.");
 
             _gfxState = _gfxStateStack.Pop();
-            Append("Q\n");
+            Append("Q");
+            _content.Append(Owner.Options.LineEnding);
         }
 
         PdfGraphicsState RestoreState(InternalGraphicsState state)
@@ -2400,11 +2525,13 @@ namespace PdfSharp.Drawing.Pdf
             var top = _gfxStateStack.Pop();
             while (top.InternalState != state)
             {
-                Append("Q\n");
+                Append("Q");
+                _content.Append(Owner.Options.LineEnding);
                 count++;
                 top = _gfxStateStack.Pop();
             }
-            Append("Q\n");
+            Append("Q");
+            _content.Append(Owner.Options.LineEnding);
             _gfxState = top;
             return top;
         }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.AcroForms/PdfTextField.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.AcroForms/PdfTextField.cs
@@ -217,7 +217,7 @@ namespace PdfSharp.Pdf.AcroForms
             string s = xobj.Stream?.ToString() ?? "";
             // Thank you Adobe: Without putting the content in 'EMC brackets'
             // the text is not rendered by PDF Reader 9 or higher.
-            s = "/Tx BMC\n" + s + "\nEMC";
+            s = "/Tx BMC" + _document.Options.LineEnding + s + _document.Options.LineEnding + "EMC";
             if (xobj.Stream != null)
                 xobj.Stream.Value = new RawEncoding().GetBytes(s);
 #endif

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceTable.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceTable.cs
@@ -29,10 +29,6 @@ namespace PdfSharp.Pdf.Advanced
     /// </remarks>
     sealed class PdfCrossReferenceTable(PdfDocument document) // Must not be derived from PdfObject.
     {
-        public bool EnableCompaction => document.EnableReferenceCompaction;
-
-        public bool EnableRenumbering => document.EnableReferenceRenumbering;
-
 #if TEST_CODE
         readonly Stopwatch _stopwatch = new();
 #endif
@@ -241,7 +237,7 @@ namespace PdfSharp.Pdf.Advanced
         /// </summary>
         internal int Compact()
         {
-            if (!EnableCompaction)
+            if (!document.Options.EnableReferenceCompaction)
                 return 0;
 
             // IMPROVE: remove PdfBooleanObject, PdfIntegerObject etc.
@@ -320,7 +316,7 @@ namespace PdfSharp.Pdf.Advanced
         /// </summary>
         internal void Renumber()
         {
-            if (!EnableRenumbering)
+            if (!document.Options.EnableReferenceRenumbering)
                 return;
 
             //CheckConsistence();

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceTable.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceTable.cs
@@ -181,20 +181,36 @@ namespace PdfSharp.Pdf.Advanced
         /// </summary>
         internal void WriteObject(PdfWriter writer)
         {
-            writer.WriteRaw("xref\n");
+            writer.WriteRaw("xref"); 
+            writer.WriteRaw(document.Options.LineEnding);
 
             var iRefs = AllReferences;
 
             int count = iRefs.Length;
-            writer.WriteRaw(Invariant($"0 {count + 1}\n"));
-            writer.WriteRaw(Invariant($"{0:0000000000} {65535:00000} f \n"));
+            writer.WriteRaw(Invariant($"0 {count + 1}"));
+            writer.WriteRaw(document.Options.LineEnding);
+
+            // Acrobat is very pedantic; it must be exactly 20 bytes per line.
+            switch (document.Options.LineEnding.Length)
+            {
+                case 1: writer.WriteRaw("0000000000 65535 f "); break;
+                case 2: writer.WriteRaw("0000000000 65535 f"); break;
+                default: throw new ArgumentOutOfRangeException(nameof(document.Options.LineEnding), document.Options.LineEnding.Length, "Line ending length is invalid");
+            }
+            writer.WriteRaw(document.Options.LineEnding);
 
             for (int idx = 0; idx < count; idx++)
             {
                 var iref = iRefs[idx];
 
                 // Acrobat is very pedantic; it must be exactly 20 bytes per line.
-                writer.WriteRaw(Invariant($"{iref.Position:0000000000} {iref.GenerationNumber:00000} n \n"));
+                switch (document.Options.LineEnding.Length)
+                {
+                    case 1: writer.WriteRaw(Invariant($"{iref.Position:0000000000} {iref.GenerationNumber:00000} n ")); break;
+                    case 2: writer.WriteRaw(Invariant($"{iref.Position:0000000000} {iref.GenerationNumber:00000} n")); break;
+                    default: throw new ArgumentOutOfRangeException(nameof(document.Options.LineEnding), document.Options.LineEnding.Length, "Line ending length is invalid");
+                }
+                writer.WriteRaw(document.Options.LineEnding);
             }
         }
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceTable.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfCrossReferenceTable.cs
@@ -29,6 +29,10 @@ namespace PdfSharp.Pdf.Advanced
     /// </remarks>
     sealed class PdfCrossReferenceTable(PdfDocument document) // Must not be derived from PdfObject.
     {
+        public bool EnableCompaction => document.EnableReferenceCompaction;
+
+        public bool EnableRenumbering => document.EnableReferenceRenumbering;
+
 #if TEST_CODE
         readonly Stopwatch _stopwatch = new();
 #endif
@@ -237,6 +241,9 @@ namespace PdfSharp.Pdf.Advanced
         /// </summary>
         internal int Compact()
         {
+            if (!EnableCompaction)
+                return 0;
+
             // IMPROVE: remove PdfBooleanObject, PdfIntegerObject etc.
             int removed = _objectTable.Count;
             PdfReference[] irefs = TransitiveClosure(document.Trailer);
@@ -313,6 +320,9 @@ namespace PdfSharp.Pdf.Advanced
         /// </summary>
         internal void Renumber()
         {
+            if (!EnableRenumbering)
+                return;
+
             //CheckConsistence();
             PdfReference[] irefs = AllReferences;
             _objectTable.Clear();

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfReference.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfReference.cs
@@ -100,7 +100,13 @@ namespace PdfSharp.Pdf.Advanced
             // PDFsharp does not yet support PDF 1.5 object streams for writing.
 
             // Each line must be exactly 20 bytes long, otherwise Acrobat repairs the file.
-            writer.WriteRaw(Invariant($"{_position:0000000000} {_objectID.GenerationNumber:00000} n \n"));
+            switch (Document.Options.LineEnding.Length)
+            {
+                case 1: writer.WriteRaw(Invariant($"{_position:0000000000} {_objectID.GenerationNumber:00000} n ")); break;
+                case 2: writer.WriteRaw(Invariant($"{_position:0000000000} {_objectID.GenerationNumber:00000} n")); break;
+                default: throw new ArgumentOutOfRangeException(nameof(Document.Options.LineEnding), Document.Options.LineEnding.Length, "Line ending length is invalid");
+            }
+            writer.WriteRaw(Document.Options.LineEnding);
         }
 
         /// <summary>

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfToUnicodeMap.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Advanced/PdfToUnicodeMap.cs
@@ -38,11 +38,11 @@ namespace PdfSharp.Pdf.Advanced
 
             // This code comes literally from PDF Reference.
             string prefix =
-              "/CIDInit /ProcSet findresource begin\n" +
-              "12 dict begin\n" +
-              "begincmap\n" +
-              "/CIDSystemInfo << /Registry (Adobe)/Ordering (UCS)/Supplement 0>> def\n" +
-              "/CMapName /Adobe-Identity-UCS def /CMapType 2 def\n";
+              "/CIDInit /ProcSet findresource begin" + _document.Options.LineEnding +
+              "12 dict begin" + _document.Options.LineEnding +
+              "begincmap" + _document.Options.LineEnding +
+              "/CIDSystemInfo << /Registry (Adobe)/Ordering (UCS)/Supplement 0>> def" + _document.Options.LineEnding +
+              "/CMapName /Adobe-Identity-UCS def /CMapType 2 def" + _document.Options.LineEnding;
             string suffix = "endcmap CMapName currentdict /CMap defineresource pop end end";
 
             //var glyphIndexToCharacter = new Dictionary<int, char>();

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Content/ContentWriter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Content/ContentWriter.cs
@@ -68,6 +68,7 @@ namespace PdfSharp.Pdf.Content
             _lastCat = GetCategory((char)bytes[bytes.Length - 1]);
         }
 
+        [Obsolete("Does not honor document line endings")]
         public void WriteLineRaw(string rawString)
         {
             if (String.IsNullOrEmpty(rawString))
@@ -148,6 +149,7 @@ namespace PdfSharp.Pdf.Content
             WriteSeparator(cat, '\0');
         }
 
+        [Obsolete("Does not honor document line endings")]
         public void NewLine()
         {
             if (_lastCat != CharCat.NewLine)

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Lexer.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/Lexer.cs
@@ -1180,7 +1180,7 @@ namespace PdfSharp.Pdf.IO
                         //Chars.SP => "・",  // U+30FB
 
                         //<= ' ' => $"⁌((int)ch).ToString(\"X2\")⁍",
-                        <= ' ' => $"""⟬{(((int)ch).ToString("X2"))}⟭""",
+                        <= ' ' => $"⟬{(int)ch:X2}⟭",
 
                         _ => ch.ToString()
                     };

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -288,6 +288,7 @@ namespace PdfSharp.Pdf.IO
                 _document.Options.EnableOwnBinaryHeader = _options.EnableOwnBinaryHeader;
                 _document.Options.EnableLineBreakInArrayObjects = _options.EnableLineBreakInArrayObjects;
                 _document.Options.DisablePagesAndCatalogAtEnd = _options.DisablePagesAndCatalogAtEnd;
+                _document.Options.EnableOwnerPasswordSecurityChecks = _options.EnableOwnerPasswordSecurityChecks;
 
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
@@ -380,7 +381,11 @@ namespace PdfSharp.Pdf.IO
                             goto TryAgain;
                         }
                         else
-                            throw new PdfReaderException(PsMsgs.OwnerPasswordRequired);
+                        {
+                            if(_document.Options.EnableOwnerPasswordSecurityChecks)
+                                throw new PdfReaderException(PsMsgs.OwnerPasswordRequired);
+                            _document.SecuritySettings.HasOwnerPermissions = true;
+                        }
                     }
                     // ReSharper restore RedundantIfElseBlock
                 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -278,8 +278,9 @@ namespace PdfSharp.Pdf.IO
 
                 var lexer = new Lexer(stream, _logger);
                 _document = new PdfDocument(lexer);
-                _document.EnableReferenceCompaction = _options.EnableReferenceCompaction;
-                _document.EnableReferenceRenumbering = _options.EnableReferenceRenumbering;
+                _document.Options.EnableReferenceCompaction = _options.EnableReferenceCompaction;
+                _document.Options.EnableReferenceRenumbering = _options.EnableReferenceRenumbering;
+                _document.Options.EnableImplicitTransparencyGroup = _options.EnableImplicitTransparencyGroup;
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -267,8 +267,7 @@ namespace PdfSharp.Pdf.IO
         /// <summary>
         /// Opens a PDF document from a stream.
         /// </summary>
-        PdfDocument OpenFromStream(Stream stream, string? password, PdfDocumentOpenMode openMode,
-            PdfPasswordProvider? passwordProvider, PdfReaderOptions? options = null)
+        PdfDocument OpenFromStream(Stream stream, string? password, PdfDocumentOpenMode openMode, PdfPasswordProvider? passwordProvider)
         {
             try
             {
@@ -279,6 +278,8 @@ namespace PdfSharp.Pdf.IO
 
                 var lexer = new Lexer(stream, _logger);
                 _document = new PdfDocument(lexer);
+                _document.EnableReferenceCompaction = _options.EnableReferenceCompaction;
+                _document.EnableReferenceRenumbering = _options.EnableReferenceRenumbering;
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
 
@@ -310,7 +311,7 @@ namespace PdfSharp.Pdf.IO
                 // After reading all objects, all documents placeholder references get replaced by references knowing their objects in FinishReferences(),
                 // which finally sets IsUnderConstruction to false.
                 _document.IrefTable.IsUnderConstruction = true;
-                var parser = new Parser(_document, options ?? new PdfReaderOptions(), _logger);
+                var parser = new Parser(_document, _options , _logger);
 
                 // 1. Read all trailers or cross-reference streams, but no objects.
                 _document.Trailer = parser.ReadTrailer();

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -282,6 +282,7 @@ namespace PdfSharp.Pdf.IO
                 _document.Options.EnableReferenceRenumbering = _options.EnableReferenceRenumbering;
                 _document.Options.EnableImplicitTransparencyGroup = _options.EnableImplicitTransparencyGroup;
                 _document.Options.EnableImplicitMetadata = _options.EnableImplicitMetadata;
+                _document.Options.EnableWriterCommentInTrailer = _options.EnableWriterCommentInTrailer;
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -278,12 +278,17 @@ namespace PdfSharp.Pdf.IO
 
                 var lexer = new Lexer(stream, _logger);
                 _document = new PdfDocument(lexer);
-                _document.Options.EnableReferenceCompaction = _options.EnableReferenceCompaction;
+
                 _document.Options.EnableReferenceRenumbering = _options.EnableReferenceRenumbering;
+                _document.Options.EnableReferenceCompaction = _options.EnableReferenceCompaction;
                 _document.Options.EnableImplicitTransparencyGroup = _options.EnableImplicitTransparencyGroup;
                 _document.Options.EnableImplicitMetadata = _options.EnableImplicitMetadata;
                 _document.Options.EnableWriterCommentInTrailer = _options.EnableWriterCommentInTrailer;
                 _document.Options.EnableLfLineEndings = _options.EnableLfLineEndings;
+                _document.Options.EnableOwnBinaryHeader = _options.EnableOwnBinaryHeader;
+                _document.Options.EnableLineBreakInArrayObjects = _options.EnableLineBreakInArrayObjects;
+                _document.Options.DisablePagesAndCatalogAtEnd = _options.DisablePagesAndCatalogAtEnd;
+
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -281,6 +281,7 @@ namespace PdfSharp.Pdf.IO
                 _document.Options.EnableReferenceCompaction = _options.EnableReferenceCompaction;
                 _document.Options.EnableReferenceRenumbering = _options.EnableReferenceRenumbering;
                 _document.Options.EnableImplicitTransparencyGroup = _options.EnableImplicitTransparencyGroup;
+                _document.Options.EnableImplicitMetadata = _options.EnableImplicitMetadata;
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -283,6 +283,7 @@ namespace PdfSharp.Pdf.IO
                 _document.Options.EnableImplicitTransparencyGroup = _options.EnableImplicitTransparencyGroup;
                 _document.Options.EnableImplicitMetadata = _options.EnableImplicitMetadata;
                 _document.Options.EnableWriterCommentInTrailer = _options.EnableWriterCommentInTrailer;
+                _document.Options.EnableLfLineEndings = _options.EnableLfLineEndings;
                 _document._state |= DocumentState.Imported;
                 _document._openMode = openMode;
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -141,6 +141,8 @@ namespace PdfSharp.Pdf.IO
 
         public bool DisablePagesAndCatalogAtEnd { get; set; } = true;
 
+        public bool EnableOwnerPasswordSecurityChecks { get; set; } = true;
+
         // Testing only
 
         //public bool UseOldCode { get; set; } = false;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -109,6 +109,8 @@ namespace PdfSharp.Pdf.IO
 
         public bool EnableWriterCommentInTrailer { get; set; } = true;
 
+        public bool EnableLfLineEndings { get; set; } = true;
+
         // Testing only
 
         //public bool UseOldCode { get; set; } = false;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -105,6 +105,8 @@ namespace PdfSharp.Pdf.IO
 
         public bool EnableImplicitTransparencyGroup { get; set; } = true;
 
+        public bool EnableImplicitMetadata { get; set; } = true;
+
         // Testing only
 
         //public bool UseOldCode { get; set; } = false;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -99,17 +99,47 @@ namespace PdfSharp.Pdf.IO
 
         public ReaderProblemDelegate? ReaderProblemCallback { get; set; }
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableReferenceRenumbering { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableReferenceCompaction { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableImplicitTransparencyGroup { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableImplicitMetadata { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableWriterCommentInTrailer { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableLfLineEndings { get; set; } = true;
+
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
+        public bool EnableOwnBinaryHeader { get; set; } = true;
+
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
+        public bool EnableLineBreakInArrayObjects { get; set; } = true;
+
+        public bool DisablePagesAndCatalogAtEnd { get; set; } = true;
 
         // Testing only
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -107,6 +107,8 @@ namespace PdfSharp.Pdf.IO
 
         public bool EnableImplicitMetadata { get; set; } = true;
 
+        public bool EnableWriterCommentInTrailer { get; set; } = true;
+
         // Testing only
 
         //public bool UseOldCode { get; set; } = false;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -99,6 +99,10 @@ namespace PdfSharp.Pdf.IO
 
         public ReaderProblemDelegate? ReaderProblemCallback { get; set; }
 
+        public bool EnableReferenceRenumbering { get; set; } = true;
+
+        public bool EnableReferenceCompaction { get; set; } = true;
+
         // Testing only
 
         //public bool UseOldCode { get; set; } = false;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfReaderOptions.cs
@@ -103,6 +103,8 @@ namespace PdfSharp.Pdf.IO
 
         public bool EnableReferenceCompaction { get; set; } = true;
 
+        public bool EnableImplicitTransparencyGroup { get; set; } = true;
+
         // Testing only
 
         //public bool UseOldCode { get; set; } = false;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
@@ -357,7 +357,7 @@ namespace PdfSharp.Pdf.IO
                 if (obj is PdfArray)
                 {
                     WriteRaw("["); 
-                    WriteRaw(_document.Options.LineEnding);
+                    //WriteRaw(_document.Options.LineEnding);
                 }
                 else if (obj is PdfDictionary)
                 {
@@ -408,7 +408,7 @@ namespace PdfSharp.Pdf.IO
             {
                 if (indirect)
                 {
-                    WriteRaw(_document.Options.LineEnding); 
+                    //WriteRaw(_document.Options.LineEnding); 
                     WriteRaw("]"); 
                     WriteRaw(_document.Options.LineEnding);
                     _lastCat = CharCat.NewLine;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
@@ -548,7 +548,8 @@ namespace PdfSharp.Pdf.IO
 
         public void WriteEof(PdfDocument document, SizeType startxref)
         {
-            WriteRaw($"% Created with PDFsharp {PdfSharpProductVersionInformation.SemanticVersion} ({Capabilities.Build.BuildName}) under .NET {Capabilities.Build.Framework}\n");
+            if(document.Options.EnableWriterCommentInTrailer)
+                WriteRaw($"% Created with PDFsharp {PdfSharpProductVersionInformation.SemanticVersion} ({Capabilities.Build.BuildName}) under .NET {Capabilities.Build.Framework}\n");
             WriteRaw("startxref\n");
             WriteRaw(startxref.ToString(CultureInfo.InvariantCulture));
             WriteRaw("\n%%EOF\n");

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
@@ -559,7 +559,8 @@ namespace PdfSharp.Pdf.IO
             int version = document._version;
             WriteRaw(Invariant($"%PDF-{version / 10}.{version % 10}"));
             WriteRaw(document.Options.LineEnding);
-            WriteRaw("%\xD3\xF4\xCC\xE1");
+            //WriteRaw("%\xD3\xF4\xCC\xE1");
+            WriteRaw("%\xE2\xE3\xCF\xD3");
             WriteRaw(document.Options.LineEnding);
 
             if (Layout == PdfWriterLayout.Verbose)

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
@@ -357,7 +357,8 @@ namespace PdfSharp.Pdf.IO
                 if (obj is PdfArray)
                 {
                     WriteRaw("["); 
-                    //WriteRaw(_document.Options.LineEnding);
+                    if(_document.Options.EnableLineBreakInArrayObjects)
+                        WriteRaw(_document.Options.LineEnding);
                 }
                 else if (obj is PdfDictionary)
                 {
@@ -408,7 +409,8 @@ namespace PdfSharp.Pdf.IO
             {
                 if (indirect)
                 {
-                    //WriteRaw(_document.Options.LineEnding); 
+                    if (_document.Options.EnableLineBreakInArrayObjects)
+                        WriteRaw(_document.Options.LineEnding);
                     WriteRaw("]"); 
                     WriteRaw(_document.Options.LineEnding);
                     _lastCat = CharCat.NewLine;
@@ -559,8 +561,10 @@ namespace PdfSharp.Pdf.IO
             int version = document._version;
             WriteRaw(Invariant($"%PDF-{version / 10}.{version % 10}"));
             WriteRaw(document.Options.LineEnding);
-            //WriteRaw("%\xD3\xF4\xCC\xE1");
-            WriteRaw("%\xE2\xE3\xCF\xD3");
+            if(document.Options.EnableOwnBinaryHeader)
+                WriteRaw("%\xD3\xF4\xCC\xE1");
+            else
+                WriteRaw("%\xE2\xE3\xCF\xD3");
             WriteRaw(document.Options.LineEnding);
 
             if (Layout == PdfWriterLayout.Verbose)

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -361,13 +361,13 @@ namespace PdfSharp.Pdf
                 writer.WriteFileHeader(this);
                 var irefs = IrefTable.AllReferences;
                 int count = irefs.Length;
-                for (int idx = 0; idx < count; idx++)
+                foreach(var iref in irefs.Where(x=>x.Value is not PdfPages))
                 {
-                    PdfReference iref = irefs[idx];
-#if DEBUG_
-                    if (iref.ObjectNumber == 378)
-                        _ = typeof(int);
-#endif
+                    iref.Position = writer.Position;
+                    iref.Value.WriteObject(writer);
+                }
+                foreach (var iref in irefs.Where(x => x.Value is PdfPages))
+                {
                     iref.Position = writer.Position;
                     iref.Value.WriteObject(writer);
                 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -502,7 +502,8 @@ namespace PdfSharp.Pdf
 
             // #PDF-UA
             // Create PdfMetadata now to include the final document information in XMP generation.
-            Catalog.Elements.SetReference(PdfCatalog.Keys.Metadata, new PdfMetadata(this));
+            if (Options.EnableImplicitMetadata)
+                Catalog.Elements.SetReference(PdfCatalog.Keys.Metadata, new PdfMetadata(this));
         }
 
         /// <summary>

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -374,7 +374,8 @@ namespace PdfSharp.Pdf
                 // ReSharper disable once RedundantCast. Redundant only if 64 bit.
                 var startXRef = (SizeType)writer.Position;
                 IrefTable.WriteObject(writer);
-                writer.WriteRaw("trailer\n");
+                writer.WriteRaw("trailer");
+                writer.WriteRaw(Options.LineEnding);
                 Trailer.Elements.SetInteger("/Size", count + 1);
                 Trailer.WriteObject(writer);
                 writer.WriteEof(this, startXRef);

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -138,6 +138,10 @@ namespace PdfSharp.Pdf
             }
             _state = DocumentState.Disposed | DocumentState.Saved;
         }
+        
+        public bool EnableReferenceCompaction { get; set; } = true;
+
+        public bool EnableReferenceRenumbering { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a user-defined object that contains arbitrary information associated with this document.

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -138,10 +138,6 @@ namespace PdfSharp.Pdf
             }
             _state = DocumentState.Disposed | DocumentState.Saved;
         }
-        
-        public bool EnableReferenceCompaction { get; set; } = true;
-
-        public bool EnableReferenceRenumbering { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a user-defined object that contains arbitrary information associated with this document.

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocument.cs
@@ -360,23 +360,26 @@ namespace PdfSharp.Pdf
 
                 writer.WriteFileHeader(this);
                 var irefs = IrefTable.AllReferences.ToList();
-                irefs.Sort((a, b) =>
+                if (!Options.DisablePagesAndCatalogAtEnd)
                 {
-                    int getPrio(PdfReference r) => r.Value switch
+                    irefs.Sort((a, b) =>
                     {
-                        PdfPages => 1,
-                        PdfCatalog => 2,
-                        _ => 0,
-                    };
-                    var cmp = getPrio(a).CompareTo(getPrio(b));
-                    if (cmp != 0)
+                        int getPrio(PdfReference r) => r.Value switch
+                        {
+                            PdfPages => 1,
+                            PdfCatalog => 2,
+                            _ => 0,
+                        };
+                        var cmp = getPrio(a).CompareTo(getPrio(b));
+                        if (cmp != 0)
+                            return cmp;
+                        cmp = a.GenerationNumber.CompareTo(b.GenerationNumber);
+                        if (cmp != 0)
+                            return cmp;
+                        cmp = a.ObjectNumber.CompareTo(b.ObjectNumber);
                         return cmp;
-                    cmp = a.GenerationNumber.CompareTo(b.GenerationNumber);
-                    if (cmp != 0)
-                        return cmp;
-                    cmp = a.ObjectNumber.CompareTo(b.ObjectNumber);
-                    return cmp;
-                });
+                    });
+                }
                 int count = irefs.Count;
                 foreach(var iref in irefs)
                 {

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
@@ -81,5 +81,11 @@ namespace PdfSharp.Pdf
             set => _useFlateDecoderForJpegImages = value;
         }
         PdfUseFlateDecoderForJpegImages _useFlateDecoderForJpegImages = PdfUseFlateDecoderForJpegImages.Never;
+
+        public bool EnableReferenceCompaction { get; set; } = true;
+
+        public bool EnableReferenceRenumbering { get; set; } = true;
+
+        public bool EnableImplicitTransparencyGroup { get; set; } = true;
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
@@ -3,6 +3,8 @@
 
 // ReSharper disable ConvertToAutoProperty
 
+using System.Text;
+
 namespace PdfSharp.Pdf
 {
     /// <summary>
@@ -91,5 +93,11 @@ namespace PdfSharp.Pdf
         public bool EnableImplicitMetadata { get; set; } = true;
 
         public bool EnableWriterCommentInTrailer { get; set; } = true;
+
+        public bool EnableLfLineEndings { get; set; } = true;
+
+        public string LineEnding => EnableLfLineEndings ? "\n" : "\r\n";
+
+        public byte[] LineEndingBytes => Encoding.ASCII.GetBytes(LineEnding);
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
@@ -126,6 +126,8 @@ namespace PdfSharp.Pdf
 
         public bool DisablePagesAndCatalogAtEnd { get; set; } = true;
 
+        public bool EnableOwnerPasswordSecurityChecks { get; set; } = true;
+
         public string LineEnding => EnableLfLineEndings ? "\n" : "\r\n";
 
         public byte[] LineEndingBytes => Encoding.ASCII.GetBytes(LineEnding);

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
@@ -84,17 +84,47 @@ namespace PdfSharp.Pdf
         }
         PdfUseFlateDecoderForJpegImages _useFlateDecoderForJpegImages = PdfUseFlateDecoderForJpegImages.Never;
 
-        public bool EnableReferenceCompaction { get; set; } = true;
-
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableReferenceRenumbering { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
+        public bool EnableReferenceCompaction { get; set; } = true;
+
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableImplicitTransparencyGroup { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableImplicitMetadata { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableWriterCommentInTrailer { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
         public bool EnableLfLineEndings { get; set; } = true;
+
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
+        public bool EnableOwnBinaryHeader { get; set; } = true;
+
+        /// <summary>
+        /// Set to <see langword="false"/> to enable greater compatibility
+        /// </summary>
+        public bool EnableLineBreakInArrayObjects { get; set; } = true;
+
+        public bool DisablePagesAndCatalogAtEnd { get; set; } = true;
 
         public string LineEnding => EnableLfLineEndings ? "\n" : "\r\n";
 

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
@@ -89,5 +89,7 @@ namespace PdfSharp.Pdf
         public bool EnableImplicitTransparencyGroup { get; set; } = true;
 
         public bool EnableImplicitMetadata { get; set; } = true;
+
+        public bool EnableWriterCommentInTrailer { get; set; } = true;
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentOptions.cs
@@ -87,5 +87,7 @@ namespace PdfSharp.Pdf
         public bool EnableReferenceRenumbering { get; set; } = true;
 
         public bool EnableImplicitTransparencyGroup { get; set; } = true;
+
+        public bool EnableImplicitMetadata { get; set; } = true;
     }
 }

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfMetadata.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfMetadata.cs
@@ -76,45 +76,43 @@ namespace PdfSharp.Pdf
             string? pdfA = null;
             if (_document.IsPdfA)
             {
+                pdfA =  
+                "      <rdf:Description rdf:about=\"\" xmlns:pdfaid=\"http://www.aiim.org/pdfa/ns/id/\">" + _document.Options.LineEnding +
+                "        <pdfaid:part>1</pdfaid:part>" + _document.Options.LineEnding +
+                "        <pdfaid:conformance>A</pdfaid:conformance>" + _document.Options.LineEnding +
+                "      </rdf:Description>";
                 // #PDF-A
-                pdfA = $"""
-                              <rdf:Description rdf:about="" xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/">
-                                <pdfaid:part>1</pdfaid:part>
-                                <pdfaid:conformance>A</pdfaid:conformance>
-                              </rdf:Description>
-                        """;
             }
 #if true
             // Created based on a PDF created with Microsoft Word.
-            var str = $"""
-                <?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
-                  <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="3.1-701">
-                    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-                      <rdf:Description rdf:about="" xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
-                        <pdf:Producer>{producer}</pdf:Producer><pdf:Keywords>{keywords}</pdf:Keywords>
-                      </rdf:Description>
-                      <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
-                        <dc:title><rdf:Alt><rdf:li xml:lang="x-default">{title}</rdf:li></rdf:Alt></dc:title>
-                        <dc:creator><rdf:Seq><rdf:li>{author}</rdf:li></rdf:Seq></dc:creator>
-                        <dc:description><rdf:Alt><rdf:li xml:lang="x-default">{subject}</rdf:li></rdf:Alt></dc:description>
-                      </rdf:Description>
-                      <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
-                        <xmp:CreatorTool>{creator}</xmp:CreatorTool>
-                        <xmp:CreateDate>{creationDate}</xmp:CreateDate>
-                        <xmp:ModifyDate>{modificationDate}</xmp:ModifyDate>
-                      </rdf:Description>
-                      <rdf:Description rdf:about="" xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/">
-                        <xmpMM:DocumentID>uuid:{documentId}</xmpMM:DocumentID>
-                        <xmpMM:InstanceID>uuid:{instanceId}</xmpMM:InstanceID>
-                      </rdf:Description>
-                {pdfA}
-                    </rdf:RDF>
-                  </x:xmpmeta>
-                <?xpacket end="w"?>
-                """;
+            var str =
+                "<?xpacket begin=\"ï»¿\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>" + _document.Options.LineEnding +
+                "  <x:xmpmeta xmlns:x=\"adobe:ns:meta/\" x:xmptk=\"3.1-701\">" + _document.Options.LineEnding +
+                "    <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">" + _document.Options.LineEnding +
+                "      <rdf:Description rdf:about=\"\" xmlns:pdf=\"http://ns.adobe.com/pdf/1.3/\">" + _document.Options.LineEnding +
+               $"        <pdf:Producer>{producer}</pdf:Producer><pdf:Keywords>{keywords}</pdf:Keywords>" + _document.Options.LineEnding +
+                "      </rdf:Description>" + _document.Options.LineEnding +
+                "      <rdf:Description rdf:about=\"\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" + _document.Options.LineEnding +
+               $"        <dc:title><rdf:Alt><rdf:li xml:lang=\"x-default\">{title}</rdf:li></rdf:Alt></dc:title>" + _document.Options.LineEnding +
+               $"        <dc:creator><rdf:Seq><rdf:li>{author}</rdf:li></rdf:Seq></dc:creator>" + _document.Options.LineEnding +
+               $"        <dc:description><rdf:Alt><rdf:li xml:lang=\"x-default\">{subject}</rdf:li></rdf:Alt></dc:description>" + _document.Options.LineEnding +
+                "      </rdf:Description>" + _document.Options.LineEnding +
+                "      <rdf:Description rdf:about=\"\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\">" + _document.Options.LineEnding +
+               $"        <xmp:CreatorTool>{creator}</xmp:CreatorTool>" + _document.Options.LineEnding +
+               $"        <xmp:CreateDate>{creationDate}</xmp:CreateDate>" + _document.Options.LineEnding +
+               $"        <xmp:ModifyDate>{modificationDate}</xmp:ModifyDate>" + _document.Options.LineEnding +
+                "      </rdf:Description>" + _document.Options.LineEnding +
+                "      <rdf:Description rdf:about=\"\" xmlns:xmpMM=\"http://ns.adobe.com/xap/1.0/mm/\">" + _document.Options.LineEnding +
+               $"        <xmpMM:DocumentID>uuid:{documentId}</xmpMM:DocumentID>" + _document.Options.LineEnding +
+               $"        <xmpMM:InstanceID>uuid:{instanceId}</xmpMM:InstanceID>" + _document.Options.LineEnding +
+                "      </rdf:Description>" + _document.Options.LineEnding +
+                pdfA + _document.Options.LineEnding +
+                "    </rdf:RDF>" + _document.Options.LineEnding +
+                "  </x:xmpmeta>" + _document.Options.LineEnding +
+                "<?xpacket end=\"w\"?>";
 #else
             // Does not exist anymore.
-            // XMP Documentation: http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart1.pdf
+            // XMP Documentation: http://www.images.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart1.pdf
 
         var str =
             // UTF-8 Byte order mark "ï»¿" and GUID (like in Reference) to avoid accidental usage in data stream.

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfOutline.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfOutline.cs
@@ -610,7 +610,7 @@ namespace PdfSharp.Pdf
         internal override void WriteObject(PdfWriter writer)
         {
 #if DEBUG
-            writer.WriteRaw("% Title = " + FilterUnicode(Title) + "\n");
+            writer.WriteRaw("% Title = " + FilterUnicode(Title) + Owner.Options.LineEnding);//
 #endif
             // TODO_OLD: Proof that there is nothing to do here.
             bool hasKids = HasChildren;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfPage.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfPage.cs
@@ -815,7 +815,7 @@ namespace PdfSharp.Pdf
                 // we respect this and skip the transparency group.
                 TransparencyUsed = true; // TODO_OLD: check XObjects
                 if (TransparencyUsed && !Elements.ContainsKey(Keys.Group) &&
-                    _document.Options.ColorMode != PdfColorMode.Undefined)
+                    _document.Options.ColorMode != PdfColorMode.Undefined && _document.Options.EnableImplicitTransparencyGroup)
                 {
                     var group = new PdfDictionary();
                     Elements["/Group"] = group;

--- a/src/foundation/src/PDFsharp/src/PdfSharp/UniversalAccessibility/StructureElementStack.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/UniversalAccessibility/StructureElementStack.cs
@@ -110,13 +110,15 @@ namespace PdfSharp.UniversalAccessibility
         {
             base.BeginItem();
             // Begin marked content.
-            StructureBuilder.Content.Write($"{Tag}<</MCID {Mcid}>>BDC\n");
+            StructureBuilder.Content.Write($"{Tag}<</MCID {Mcid}>>BDC");
+            StructureBuilder.Content.Write(StructureBuilder.UaManager.Owner.Options.LineEnding);
         }
 
         public override void EndItem()
         {
             // End marked content.
-            StructureBuilder.Content.Write("EMC\n");
+            StructureBuilder.Content.Write("EMC");
+            StructureBuilder.Content.Write(StructureBuilder.UaManager.Owner.Options.LineEnding);
             base.EndItem();
         }
     }
@@ -134,13 +136,15 @@ namespace PdfSharp.UniversalAccessibility
         {
             base.BeginItem();
             // Begin artifact.
-            StructureBuilder.Content.Write("/Artifact BMC\n");
+            StructureBuilder.Content.Write("/Artifact BMC");
+            StructureBuilder.Content.Write(StructureBuilder.UaManager.Owner.Options.LineEnding);
         }
 
         public override void EndItem()
         {
             // End artifact.
-            StructureBuilder.Content.Write("EMC\n");
+            StructureBuilder.Content.Write("EMC");
+            StructureBuilder.Content.Write(StructureBuilder.UaManager.Owner.Options.LineEnding);
             base.EndItem();
         }
     }

--- a/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/IO/WriterTests.cs
+++ b/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/IO/WriterTests.cs
@@ -6,6 +6,7 @@ using PdfSharp.Diagnostics;
 using PdfSharp.Drawing;
 using PdfSharp.Fonts;
 using PdfSharp.Pdf;
+using PdfSharp.Pdf.Advanced;
 using PdfSharp.Pdf.IO;
 using PdfSharp.Quality;
 using PdfSharp.Snippets.Font;
@@ -28,6 +29,55 @@ namespace PdfSharp.Tests.IO
 
             Action save = () => doc.Save(filename);
             save.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Memory_Write_import_file()
+        {
+            var testFile = IOUtility.GetAssetsPath("archives/samples-1.5/PDFs/SomeLayout.pdf")!;
+
+            var doc = PdfReader.Open(testFile, PdfDocumentOpenMode.Import);
+
+            Action save = () =>
+            {
+                using var mem = new MemoryStream();
+                doc.Save(mem);
+            };
+            save.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Memory_Write_modify_file()
+        {
+            var testFile = IOUtility.GetAssetsPath("archives/samples-1.5/PDFs/SomeLayout.pdf")!;
+
+            var doc = PdfReader.Open(testFile, PdfDocumentOpenMode.Modify);
+
+            Action save = () =>
+            {
+                using var mem = new MemoryStream();
+                doc.Save(mem);
+            };
+            save.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Memory_Write_modify_file2()
+        {
+            var testFile = @"C:\Projekty\PDForge\ValidatorTests\in.pdf";
+
+            var doc = PdfReader.Open(testFile, PdfDocumentOpenMode.Modify, new PdfReaderOptions()
+            {
+                EnableReferenceCompaction = false,
+                EnableReferenceRenumbering = false,
+            });
+
+            Action save = () =>
+            {
+                using var mem = new MemoryStream();
+                doc.Save(mem);
+            };
+            save.Should().NotThrow();
         }
     }
 }


### PR DESCRIPTION
Added couple compatibility options for writing/reading the PDF file:

Accessible as properties in: `PdfReaderOptions` and `PdfDocumentOptions`

```
        public bool EnableReferenceRenumbering { get; set; } = true;
        public bool EnableReferenceCompaction { get; set; } = true;
        public bool EnableImplicitTransparencyGroup { get; set; } = true;
        public bool EnableImplicitMetadata { get; set; } = true;
        public bool EnableWriterCommentInTrailer { get; set; } = true;
        public bool EnableLfLineEndings { get; set; } = true;
        public bool EnableOwnBinaryHeader { get; set; } = true;
        public bool EnableLineBreakInArrayObjects { get; set; } = true;
        public bool DisablePagesAndCatalogAtEnd { get; set; } = true;
```

Mainly to align the binary format of the file to match SAP/Acrobat more closely and fix printing issues on Ricoh printers. 

Setting them to non default values enables the patch.