### PR TITLE
Some valid JPEG files may not be loaded using XImage.FromFile()

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Drawing.Internal/ImageImporterJpeg.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Drawing.Internal/ImageImporterJpeg.cs
@@ -28,24 +28,23 @@ namespace PdfSharp.Drawing.Internal
                     var ipd = new ImagePrivateDataDct(stream.Data, stream.Length);
                     var ii = new ImportedImageJpeg(ipd);
                     ii.Information.DefaultDPI = 72; // Assume 72 DPI if information not provided in the file.
-                    if (TestJfifHeader(stream, ii))
-                    {
-                        bool colorHeader = false, infoHeader = false;
+                    TestJfifHeader(stream, ii); // App headers are optional
 
-                        while (MoveToNextHeader(stream))
+                    bool colorHeader = false, infoHeader = false;
+
+                    while (MoveToNextHeader(stream))
+                    {
+                        if (TestColorFormatHeader(stream, ii))
                         {
-                            if (TestColorFormatHeader(stream, ii))
-                            {
-                                colorHeader = true;
-                            }
-                            else if (TestInfoHeader(stream, ii))
-                            {
-                                infoHeader = true;
-                            }
+                            colorHeader = true;
                         }
-                        if (colorHeader && infoHeader)
-                            return ii;
+                        else if (TestInfoHeader(stream, ii))
+                        {
+                            infoHeader = true;
+                        }
                     }
+                    if (colorHeader && infoHeader)
+                        return ii;
                 }
             }
             // ReSharper disable once EmptyGeneralCatchClause


### PR DESCRIPTION
Fixes #256.

Some JPEG files don't include any app headers at all (sometimes called "raw" JPEGs - not to be confused with RAW files). In my case, JPEGs captured by [FlashCap](https://github.com/kekyo/FlashCap) sometimes didn't have them.

This PR makes app headers optional so that PDFsharp can successfully import them.