### PR TITLE
Fix nested composite glyph closure in font subsetter, fixes #348

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/GlyphDataTable.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Fonts.OpenType/GlyphDataTable.cs
@@ -89,9 +89,6 @@ namespace PdfSharp.Fonts.OpenType
         /// </summary>
         public void CompleteGlyphClosure(Dictionary<ushort, object?> glyphs)
         {
-            int count = glyphs.Count;
-            ushort[] glyphArray = new ushort[glyphs.Count];
-            glyphs.Keys.CopyTo(glyphArray, 0);
             // ReSharper disable once CanSimplifyDictionaryLookupWithTryAdd because of .NET Framework
             if (!glyphs.ContainsKey(0))
                 glyphs.Add(0, null);
@@ -101,8 +98,16 @@ namespace PdfSharp.Fonts.OpenType
             try
             {
                 Locks.EnterFontFactory();
-                for (int idx = 0; idx < count; idx++)
-                    AddCompositeGlyphs(glyphs, glyphArray[idx]);
+                // Iterate until no new glyphs are discovered (transitive closure for nested composites).
+                int previousCount;
+                do
+                {
+                    previousCount = glyphs.Count;
+                    ushort[] glyphArray = new ushort[previousCount];
+                    glyphs.Keys.CopyTo(glyphArray, 0);
+                    for (int idx = 0; idx < previousCount; idx++)
+                        AddCompositeGlyphs(glyphs, glyphArray[idx]);
+                } while (glyphs.Count > previousCount);
             }
             finally { Locks.ExitFontFactory(); }
         }


### PR DESCRIPTION
GlyphDataTable.CompleteGlyphClosure() durchläuft die Menge der benötigten Glyphen nur einmal, um zusammengesetzte Glyphen in ihre Bestandteile aufzulösen. Sobald ein Composite Glyph als verschachtelte Komposition auf einen weiteren Composite Glyph verweist, werden die transitiven Abhängigkeiten nicht erkannt. Das resultierende Font-Subset ist unvollständig, siehe #348.