### PR TITLE
HeaderFooter fix for PDF

### DIFF
--- a/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/FormattedDocument.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/FormattedDocument.cs
@@ -386,8 +386,9 @@ namespace MigraDoc.Rendering
             ++_sectionPages;
             InitFieldInfos();
             FormatHeadersFooters();
+            Rectangle rect = CalcContentRect(_currentPage);
             _isNewSection = false;
-            return CalcContentRect(_currentPage);
+            return rect;
         }
 
         int _currentPage;

--- a/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/FormattedDocument.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/FormattedDocument.cs
@@ -193,10 +193,16 @@ namespace MigraDoc.Rendering
 
             XUnitPt height = pageSetup.PageHeight.Point;
 
-            height -= pageSetup.TopMargin.Point;
-            height -= pageSetup.BottomMargin.Point;
+            double topMargin = pageSetup.TopMargin.Point;
+            if (_formattedHeaders.TryGetValue(new HeaderFooterPosition(_sectionNumber, CurrentPagePosition), out FormattedHeaderFooter? header))
+                topMargin = Math.Max(topMargin, header.ContentRect.Y.Point + header.ContentRect.Height.Point);
+            height -= topMargin;
+            double bottomMargin = pageSetup.BottomMargin.Point;
+            if (_formattedFooters.TryGetValue(new HeaderFooterPosition(_sectionNumber, CurrentPagePosition), out FormattedHeaderFooter? footer))
+                bottomMargin = Math.Max(bottomMargin, pageSetup.PageHeight.Value - footer.ContentRect.Y.Point);
+            height -= bottomMargin;
             XUnitPt x;
-            XUnitPt y = pageSetup.TopMargin.Point;
+            XUnitPt y = topMargin;
             if (pageSetup.MirrorMargins)
                 x = page % 2 == 0 ? pageSetup.RightMargin.Point : pageSetup.LeftMargin.Point;
             else

--- a/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/FormattedHeaderFooter.cs
+++ b/src/foundation/src/MigraDoc/src/MigraDoc.Rendering/Rendering/FormattedHeaderFooter.cs
@@ -25,6 +25,13 @@ namespace MigraDoc.Rendering
             _formatter = new TopDownFormatter(this, _documentRenderer, _headerFooter.Elements);
             _formatter.FormatOnAreas(gfx, false);
             _contentHeight = RenderInfo.GetTotalHeight(GetRenderInfos());
+            if (_headerFooter.IsHeader)
+                ContentRect.Height = _contentHeight;
+            if (_headerFooter.IsFooter)
+            {
+                ContentRect.Y = ContentRect.Y + ContentRect.Height - _contentHeight;
+                ContentRect.Height = _contentHeight;
+            }
         }
 
         Area? IAreaProvider.GetNextArea()


### PR DESCRIPTION
## Summary

This PR fixes a layout inconsistency between RTF and PDF rendering when using large headers.

## Problem
When a large header is defined, the RTF output correctly shifts the normal page content downward.
<img width="1067" height="534" alt="image" src="https://github.com/user-attachments/assets/fd531a00-97bd-49a2-b490-4ff3209c6ebd" />

The PDF output, however, could render the header on top of the page content, causing an overlap.
<img width="844" height="370" alt="image" src="https://github.com/user-attachments/assets/bf413dcc-6414-44e7-8466-7fa935003911" />

## Reproduction

1. Create a document with a large multi-line header
2. Generate both **RTF** and **PDF**
3. Open the generated files
4. Compare the start position of the normal page content

## Fix
With this fix, PDF rendering now respects the header height and positions the page content accordingly, resulting in output that is visually consistent with the RTF rendering.
<img width="828" height="391" alt="image" src="https://github.com/user-attachments/assets/4639b365-1328-41b1-b629-418dec6cb08c" />

