### PR TITLE
Define the polyfills of DynamicallyAccessedMembers only where they are missing

### DIFF
--- a/src/foundation/src/shared/src/PdfSharp.Shared/dotnet/CodeAnalysis.cs
+++ b/src/foundation/src/shared/src/PdfSharp.Shared/dotnet/CodeAnalysis.cs
@@ -3,7 +3,10 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
-#if !NET8_0_OR_GREATER
+// These types exist since .NET 5, so they must only be defined for the frameworks that do not have them.
+// A build for .NET 6 or .NET 7 fails with CS0433 (type exists in two assemblies) if the condition is
+// '!NET8_0_OR_GREATER'.
+#if NET462 || NETSTANDARD2_0
     /// <summary>
     /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
     /// for example through <see cref="Reflection"/>.


### PR DESCRIPTION
`DynamicallyAccessedMembersAttribute` and `DynamicallyAccessedMemberTypes` in `PdfSharp.Shared/dotnet/CodeAnalysis.cs` are compiled for every target framework below .NET 8:

```csharp
#if !NET8_0_OR_GREATER
```

Both types exist since .NET 5, so building the sources for .NET 6 or .NET 7 fails with `CS0433` — the type exists in both `PdfSharp.Shared` and `System.Runtime` (388 errors in my build for `net6.0`).

The condition is now `NET462 || NETSTANDARD2_0`, i.e. the polyfills are compiled where the types are really missing. `PdfSharp.System/dotnet/CodeAnalysis.cs` already disables its copy for the same reason.

No effect on the target frameworks PDFsharp is built for today — the block was already excluded for net8.0/net9.0/net10.0 and is unchanged for netstandard2.0.

Verified on top of current `master`: builds for `net10.0` and `netstandard2.0`, full `PdfSharp.Tests` suite green (252 passed, 0 failed).

This PR is independent of my other PRs; each of them applies to `master` on its own.
