### PR TITLE
Write rectangles with the precision of real numbers

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.IO/PdfWriter.cs
@@ -236,7 +236,14 @@ namespace PdfSharp.Pdf.IO
         /// </summary>
         public void Write(PdfRectangle rect)
         {
-            const string format = Config.SignificantDecimalPlaces3;
+            // With three decimal places, writing an existing page rounds its /MediaBox
+            // (e.g. 595.2756 -> 595.276). That is a change of the page geometry, which a validator
+            // reports as a changed page for every digital signature the document already contains.
+            //
+            // Note that the coordinates are written as they are, while Write(double) converts a real
+            // number to a single first. Doing that here would defeat the purpose: the single nearest to
+            // 595.2756 is 595.27557, which does not round-trip either.
+            const string format = Config.SignificantDecimalPlaces7;
             WriteSeparator(CharCat.Delimiter);
             WriteRaw(PdfEncoders.Format("[{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "}]", rect.X1, rect.Y1, rect.X2, rect.Y2));
         }

--- a/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/IO/WriterTests.cs
+++ b/src/foundation/src/PDFsharp/tests/PdfSharp.Tests/IO/WriterTests.cs
@@ -29,5 +29,32 @@ namespace PdfSharp.Tests.IO
             Action save = () => doc.Save(filename);
             save.Should().Throw<InvalidOperationException>();
         }
+
+        [Fact]
+        public void Write_rectangle_with_the_precision_of_a_real_number()
+        {
+            // ISO A4 in points. The values have four decimal places, which must survive a round-trip,
+            // because a changed /MediaBox is a changed page for every digital signature of the document.
+            const double width = 595.2756, height = 841.8898;
+
+            using var stream = new MemoryStream();
+            using (var document = new PdfDocument())
+            {
+                var page = document.AddPage();
+                page.MediaBox = new PdfRectangle(new XPoint(0, 0), new XPoint(width, height));
+                document.Save(stream, false);
+            }
+
+            var pdf = stream.ToArray();
+            var chars = new char[pdf.Length];
+            for (int idx = 0; idx < pdf.Length; idx++)
+                chars[idx] = (char)pdf[idx];
+            new String(chars).Should().Contain("[0 0 595.2756 841.8898]");
+
+            using var writtenDocument = PdfReader.Open(new MemoryStream(pdf), PdfDocumentOpenMode.Import);
+            var mediaBox = writtenDocument.Pages[0].MediaBox;
+            mediaBox.X2.Should().Be(width);
+            mediaBox.Y2.Should().Be(height);
+        }
     }
 }


### PR DESCRIPTION
`PdfWriter.Write(PdfRectangle)` rounds the coordinates to three decimal places, while `Write(double)` and `Write(PdfReal)` use seven:

```csharp
const string format = Config.SignificantDecimalPlaces3;
```

Writing a document therefore changes its geometry. The `/MediaBox` of an ISO A4 page created by another producer becomes `595.276` instead of `595.2756`.

For a signed document that is a changed page: adding a second signature to a document that already contains one makes validators report the pages of the first revision as changed.

With seven decimal places `/MediaBox`, `/CropBox`, `/BleedBox`, `/TrimBox`, `/ArtBox`, `/Rect` and `/BBox` round-trip unchanged.

**Why not convert to a single first, as `Write(double)` does?** That would defeat the purpose: the single nearest to `595.2756` is `595.27557`, which does not round-trip either.

**Alternative you may prefer:** writing the value that was parsed, as `PRESERVE_PARSED_VALUES` already does for numbers. That preserves every number of a file and not only rectangles, but it needs the parsed value to survive until the document is written, which is not the case for rectangles today. Happy to go that way instead if you consider it the better fix.

**Test** (`IO/WriterTests.cs`): a page with a `/MediaBox` of four decimal places is written and read back; the test checks both the bytes in the file and the values after reading.

Verified on top of current `master`: full `PdfSharp.Tests` suite green (253 passed, 0 failed).

This PR is independent of my other PRs; each of them applies to `master` on its own.
